### PR TITLE
feat(chat): add drag-and-drop image attachment

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,9 @@
 import '@testing-library/jest-dom/vitest'
 
 beforeEach(() => {
-  localStorage.clear()
+  if (typeof localStorage !== 'undefined' && typeof localStorage.clear === 'function') {
+    localStorage.clear()
+  }
 })
 
 Object.defineProperty(navigator, 'clipboard', {


### PR DESCRIPTION
## Summary
- 채팅 입력 영역에 이미지 드래그앤드롭 첨부 기능 추가
- 기존 클릭 업로드와 동일한 검증 로직 공유

## Changes
### Modified Files
| File | Changes |
|------|---------|
| `src/components/chat/ChatInput.tsx` | 드래그앤드롭 핸들러 추가, `addImageFiles` 공통 함수 추출, 드래그 시각적 피드백, 접근성 속성 |
| `src/components/chat/ChatInput.test.tsx` | 드래그앤드롭 테스트 7개 추가 |
| `src/test/setup.ts` | jsdom 28 localStorage 호환성 수정 |

## Test Plan
- [x] 기존 테스트 20개 통과
- [x] 드래그앤드롭 테스트 7개 추가 (총 27개 통과)
- [x] 빌드 성공
- [x] 린트 통과

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)