### PR TITLE
feat(library): implement document library frontend page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Landing } from '@/pages/landing/Landing'
 import { Login } from '@/pages/Login'
 import { Register } from '@/pages/Register'
 import { Chat } from '@/pages/Chat'
+import { Library } from '@/pages/Library'
 import { SharedSession } from '@/pages/SharedSession'
 
 const queryClient = new QueryClient({
@@ -41,6 +42,7 @@ function App() {
             <Route element={<AppLayout />}>
               <Route path="/chat" element={<Chat />} />
               <Route path="/chat/:conversationId" element={<Chat />} />
+              <Route path="/library" element={<Library />} />
             </Route>
           </Route>
 

--- a/src/api/library.test.ts
+++ b/src/api/library.test.ts
@@ -1,0 +1,209 @@
+import {
+  fetchDocuments,
+  fetchDocumentDetail,
+  updateDocumentStatus,
+  deleteDocument,
+  fetchStorageUsage,
+  uploadDocument,
+} from './library'
+
+const mockJson = vi.fn()
+const mockGet = vi.fn(() => ({ json: mockJson }))
+const mockPatch = vi.fn(() => ({ json: mockJson }))
+const mockDelete = vi.fn(() => ({ json: mockJson }))
+
+vi.mock('./client', () => ({
+  apiClient: {
+    get: (...args: unknown[]) => mockGet(...args),
+    patch: (...args: unknown[]) => mockPatch(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}))
+
+describe('library API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('fetchDocuments', () => {
+    it('파라미터 없이 문서 목록을 조회한다', async () => {
+      const response = { status: 200, message: 'ok', data: { documents: [], total: 0, page: 1, size: 20 } }
+      mockJson.mockResolvedValue(response)
+
+      const result = await fetchDocuments()
+
+      expect(mockGet).toHaveBeenCalledWith('api/v1/library/documents', { searchParams: {} })
+      expect(result).toEqual(response)
+    })
+
+    it('페이지네이션 파라미터를 전달한다', async () => {
+      mockJson.mockResolvedValue({ status: 200, data: null })
+
+      await fetchDocuments({ page: 2, size: 10, include_archived: true })
+
+      expect(mockGet).toHaveBeenCalledWith('api/v1/library/documents', {
+        searchParams: { page: '2', size: '10', include_archived: 'true' },
+      })
+    })
+  })
+
+  describe('fetchDocumentDetail', () => {
+    it('문서 상세 정보를 조회한다', async () => {
+      const response = { status: 200, message: 'ok', data: { id: 1 } }
+      mockJson.mockResolvedValue(response)
+
+      const result = await fetchDocumentDetail(1)
+
+      expect(mockGet).toHaveBeenCalledWith('api/v1/library/documents/1')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('updateDocumentStatus', () => {
+    it('문서 상태를 변경한다', async () => {
+      const response = { status: 200, message: 'ok', data: { id: 1, status: 'archived' } }
+      mockJson.mockResolvedValue(response)
+
+      const result = await updateDocumentStatus(1, { status: 'archived' })
+
+      expect(mockPatch).toHaveBeenCalledWith('api/v1/library/documents/1/status', {
+        json: { status: 'archived' },
+      })
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('deleteDocument', () => {
+    it('문서를 삭제한다', async () => {
+      const response = { status: 200, message: 'ok', data: null }
+      mockJson.mockResolvedValue(response)
+
+      const result = await deleteDocument(1)
+
+      expect(mockDelete).toHaveBeenCalledWith('api/v1/library/documents/1')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('fetchStorageUsage', () => {
+    it('스토리지 사용량을 조회한다', async () => {
+      const response = {
+        status: 200,
+        message: 'ok',
+        data: { used_bytes: 1024, max_bytes: 104857600, document_count: 5 },
+      }
+      mockJson.mockResolvedValue(response)
+
+      const result = await fetchStorageUsage()
+
+      expect(mockGet).toHaveBeenCalledWith('api/v1/library/storage')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('uploadDocument', () => {
+    let mockXhr: {
+      open: ReturnType<typeof vi.fn>
+      send: ReturnType<typeof vi.fn>
+      setRequestHeader: ReturnType<typeof vi.fn>
+      upload: { addEventListener: ReturnType<typeof vi.fn> }
+      addEventListener: ReturnType<typeof vi.fn>
+      status: number
+      responseText: string
+    }
+
+    const originalXHR = globalThis.XMLHttpRequest
+    let mockStorage: Record<string, string>
+
+    beforeEach(() => {
+      mockXhr = {
+        open: vi.fn(),
+        send: vi.fn(),
+        setRequestHeader: vi.fn(),
+        upload: { addEventListener: vi.fn() },
+        addEventListener: vi.fn(),
+        status: 200,
+        responseText: '',
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const MockXHR = function (this: any) {
+        this.open = mockXhr.open
+        this.send = mockXhr.send
+        this.setRequestHeader = mockXhr.setRequestHeader
+        this.upload = mockXhr.upload
+        this.addEventListener = mockXhr.addEventListener
+        // Use getters so mutations are visible
+        Object.defineProperty(this, 'status', { get: () => mockXhr.status })
+        Object.defineProperty(this, 'responseText', { get: () => mockXhr.responseText })
+      } as unknown as typeof XMLHttpRequest
+      vi.stubGlobal('XMLHttpRequest', MockXHR)
+
+      mockStorage = {}
+      vi.stubGlobal('localStorage', {
+        getItem: vi.fn((key: string) => mockStorage[key] ?? null),
+        setItem: vi.fn((key: string, value: string) => { mockStorage[key] = value }),
+        removeItem: vi.fn((key: string) => { delete mockStorage[key] }),
+        clear: vi.fn(() => { mockStorage = {} }),
+      })
+    })
+
+    afterEach(() => {
+      vi.stubGlobal('XMLHttpRequest', originalXHR)
+    })
+
+    it('파일을 업로드하고 성공 응답을 반환한다', async () => {
+      const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+      const response = { status: 201, message: 'ok', data: { id: 1 } }
+
+      mockXhr.addEventListener.mockImplementation((event: string, handler: () => void) => {
+        if (event === 'load') {
+          mockXhr.status = 201
+          mockXhr.responseText = JSON.stringify(response)
+          setTimeout(handler, 0)
+        }
+      })
+
+      const result = await uploadDocument(file)
+
+      expect(mockXhr.open).toHaveBeenCalledWith(
+        'POST',
+        expect.stringContaining('/api/v1/library/documents'),
+      )
+      expect(result).toEqual(response)
+    })
+
+    it('업로드 진행률 콜백을 호출한다', () => {
+      const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+      const onProgress = vi.fn()
+
+      mockXhr.upload.addEventListener.mockImplementation(
+        (event: string, handler: (e: { lengthComputable: boolean; loaded: number; total: number }) => void) => {
+          if (event === 'progress') {
+            handler({ lengthComputable: true, loaded: 50, total: 100 })
+          }
+        },
+      )
+
+      mockXhr.addEventListener.mockImplementation(() => {})
+
+      uploadDocument(file, onProgress)
+
+      expect(onProgress).toHaveBeenCalledWith(50)
+    })
+
+    it('JWT 토큰을 Authorization 헤더에 설정한다', () => {
+      mockStorage['access_token'] = 'test-token'
+      const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+
+      mockXhr.addEventListener.mockImplementation(() => {})
+
+      uploadDocument(file)
+
+      expect(mockXhr.setRequestHeader).toHaveBeenCalledWith(
+        'Authorization',
+        'Bearer test-token',
+      )
+    })
+  })
+})

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -1,0 +1,100 @@
+import { apiClient } from './client'
+import { API_BASE_URL } from '@/lib/constants'
+import type { ApiResponse } from '@/types/api'
+import type {
+  LibraryDocument,
+  LibraryDocumentDetail,
+  LibraryDocumentListResponse,
+  LibraryDocumentListParams,
+  StorageUsage,
+  UpdateStatusRequest,
+} from '@/types/library'
+
+export function fetchDocuments(
+  params?: LibraryDocumentListParams,
+): Promise<ApiResponse<LibraryDocumentListResponse>> {
+  const searchParams: Record<string, string> = {}
+  if (params?.page !== undefined) searchParams.page = String(params.page)
+  if (params?.size !== undefined) searchParams.size = String(params.size)
+  if (params?.include_archived !== undefined)
+    searchParams.include_archived = String(params.include_archived)
+
+  return apiClient
+    .get('api/v1/library/documents', { searchParams })
+    .json()
+}
+
+export function fetchDocumentDetail(
+  id: number,
+): Promise<ApiResponse<LibraryDocumentDetail>> {
+  return apiClient.get(`api/v1/library/documents/${id}`).json()
+}
+
+export function updateDocumentStatus(
+  id: number,
+  data: UpdateStatusRequest,
+): Promise<ApiResponse<LibraryDocument>> {
+  return apiClient
+    .patch(`api/v1/library/documents/${id}/status`, { json: data })
+    .json()
+}
+
+export function deleteDocument(id: number): Promise<ApiResponse<null>> {
+  return apiClient.delete(`api/v1/library/documents/${id}`).json()
+}
+
+export function fetchStorageUsage(): Promise<ApiResponse<StorageUsage>> {
+  return apiClient.get('api/v1/library/storage').json()
+}
+
+export function uploadDocument(
+  file: File,
+  onProgress?: (progress: number) => void,
+): Promise<ApiResponse<LibraryDocument>> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    const formData = new FormData()
+    formData.append('file', file)
+
+    xhr.upload.addEventListener('progress', (event) => {
+      if (event.lengthComputable && onProgress) {
+        const percent = Math.round((event.loaded / event.total) * 100)
+        onProgress(percent)
+      }
+    })
+
+    xhr.addEventListener('load', () => {
+      try {
+        const response = JSON.parse(xhr.responseText) as ApiResponse<LibraryDocument>
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(response)
+        } else {
+          reject(response)
+        }
+      } catch {
+        reject(new Error('Failed to parse response'))
+      }
+    })
+
+    xhr.addEventListener('error', () => {
+      reject(new Error('Upload failed'))
+    })
+
+    xhr.open('POST', `${API_BASE_URL}/api/v1/library/documents`)
+
+    const token = localStorage.getItem('access_token')
+    if (token) {
+      xhr.setRequestHeader('Authorization', `Bearer ${token}`)
+    }
+
+    xhr.send(formData)
+  })
+}
+
+export function getDocumentDownloadUrl(id: number): string {
+  return `${API_BASE_URL}/api/v1/library/documents/${id}/download`
+}
+
+export function getDocumentPreviewUrl(id: number): string {
+  return `${API_BASE_URL}/api/v1/library/documents/${id}/preview`
+}

--- a/src/components/library/DocumentFilterToggle.tsx
+++ b/src/components/library/DocumentFilterToggle.tsx
@@ -1,0 +1,35 @@
+import { useLibraryStore } from '@/stores/libraryStore'
+import { cn } from '@/lib/utils'
+
+function DocumentFilterToggle() {
+  const { includeArchived, setIncludeArchived } = useLibraryStore()
+
+  return (
+    <div className="flex rounded-lg border border-zinc-200 dark:border-zinc-700">
+      <button
+        onClick={() => setIncludeArchived(false)}
+        className={cn(
+          'rounded-l-lg px-3 py-1.5 text-xs font-medium transition-colors',
+          !includeArchived
+            ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+            : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200',
+        )}
+      >
+        활성
+      </button>
+      <button
+        onClick={() => setIncludeArchived(true)}
+        className={cn(
+          'rounded-r-lg px-3 py-1.5 text-xs font-medium transition-colors',
+          includeArchived
+            ? 'bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900'
+            : 'text-zinc-500 hover:text-zinc-700 dark:text-zinc-400 dark:hover:text-zinc-200',
+        )}
+      >
+        전체
+      </button>
+    </div>
+  )
+}
+
+export { DocumentFilterToggle }

--- a/src/components/library/DocumentItem.tsx
+++ b/src/components/library/DocumentItem.tsx
@@ -1,0 +1,121 @@
+import { Icon } from '@iconify/react'
+import { cn } from '@/lib/utils'
+import { formatRelativeTime, formatFileSize } from '@/lib/format'
+import { useUpdateDocumentStatus, useDeleteDocument } from '@/hooks/useLibraryMutations'
+import { API_BASE_URL } from '@/lib/constants'
+import type { LibraryDocument } from '@/types/library'
+
+interface DocumentItemProps {
+  document: LibraryDocument
+  onPreview: (id: number, contentType: string) => void
+}
+
+function getFileIcon(contentType: string): string {
+  if (contentType.startsWith('image/')) return 'solar:image-linear'
+  if (contentType.startsWith('text/')) return 'solar:file-text-linear'
+  return 'solar:document-linear'
+}
+
+function DocumentItem({ document: doc, onPreview }: DocumentItemProps) {
+  const updateStatus = useUpdateDocumentStatus()
+  const deleteDoc = useDeleteDocument()
+
+  const isArchived = doc.status === 'archived'
+  const isSummarizing = doc.summary_status === 'pending' || doc.summary_status === 'processing'
+
+  function handleDownload() {
+    window.open(
+      `${API_BASE_URL}/api/v1/library/documents/${doc.id}/download`,
+      '_blank',
+    )
+  }
+
+  function handleToggleStatus() {
+    const newStatus = isArchived ? 'active' : 'archived'
+    updateStatus.mutate({ id: doc.id, data: { status: newStatus } })
+  }
+
+  function handleDelete() {
+    if (!window.confirm(`"${doc.original_filename}" 파일을 삭제하시겠습니까?`)) return
+    deleteDoc.mutate(doc.id)
+  }
+
+  return (
+    <div
+      className={cn(
+        'group flex items-start gap-3 rounded-lg border border-zinc-100 p-3 transition-colors hover:bg-zinc-50 dark:border-zinc-800 dark:hover:bg-zinc-800/50',
+        isArchived && 'opacity-50',
+      )}
+    >
+      <div className="mt-0.5 flex-shrink-0 text-zinc-400 dark:text-zinc-500">
+        <Icon icon={getFileIcon(doc.content_type)} width={20} />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-200">
+            {doc.original_filename}
+          </span>
+          {isArchived && (
+            <span className="flex-shrink-0 rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-medium text-zinc-600 dark:bg-zinc-700 dark:text-zinc-400">
+              보관됨
+            </span>
+          )}
+          {isSummarizing && (
+            <span className="flex-shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+              요약 중
+            </span>
+          )}
+        </div>
+
+        {doc.summary && (
+          <p className="mt-1 line-clamp-2 text-xs text-zinc-500 dark:text-zinc-400">
+            {doc.summary}
+          </p>
+        )}
+
+        <div className="mt-1.5 flex items-center gap-2 text-[11px] text-zinc-400 dark:text-zinc-500">
+          <span>{formatFileSize(doc.file_size)}</span>
+          <span>·</span>
+          <span>{formatRelativeTime(doc.created_at)}</span>
+        </div>
+      </div>
+
+      <div className="flex flex-shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+        <button
+          onClick={() => onPreview(doc.id, doc.content_type)}
+          title="미리보기"
+          className="rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+        >
+          <Icon icon="solar:eye-linear" width={16} />
+        </button>
+        <button
+          onClick={handleDownload}
+          title="다운로드"
+          className="rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+        >
+          <Icon icon="solar:download-linear" width={16} />
+        </button>
+        <button
+          onClick={handleToggleStatus}
+          title={isArchived ? '활성화' : '보관'}
+          className="rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-700 dark:hover:text-zinc-300"
+        >
+          <Icon
+            icon={isArchived ? 'solar:restart-linear' : 'solar:archive-linear'}
+            width={16}
+          />
+        </button>
+        <button
+          onClick={handleDelete}
+          title="삭제"
+          className="rounded p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-red-500 dark:hover:bg-zinc-700 dark:hover:text-red-400"
+        >
+          <Icon icon="solar:trash-bin-2-linear" width={16} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export { DocumentItem }

--- a/src/components/library/DocumentList.tsx
+++ b/src/components/library/DocumentList.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { Icon } from '@iconify/react'
+import { useLibraryDocuments } from '@/hooks/useLibraryDocuments'
+import { DocumentItem } from './DocumentItem'
+import { DocumentPreviewModal } from './DocumentPreviewModal'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { Alert } from '@/components/ui/Alert'
+
+function DocumentList() {
+  const [page, setPage] = useState(1)
+  const [preview, setPreview] = useState<{
+    id: number
+    contentType: string
+  } | null>(null)
+
+  const { data, isLoading, isError } = useLibraryDocuments(page)
+
+  function handlePreview(id: number, contentType: string) {
+    setPreview({ id, contentType })
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-4">
+        <Alert variant="error">문서 목록을 불러오는데 실패했습니다</Alert>
+      </div>
+    )
+  }
+
+  if (!data || data.documents.length === 0) {
+    return (
+      <div className="flex flex-1 flex-col items-center justify-center gap-2 text-zinc-400 dark:text-zinc-500">
+        <Icon icon="solar:document-linear" width={40} />
+        <p className="text-sm">아직 문서가 없습니다</p>
+        <p className="text-xs">파일을 업로드하여 라이브러리를 시작하세요</p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="flex-1 overflow-y-auto p-4">
+        <div className="flex flex-col gap-2">
+          {data.documents.map((doc) => (
+            <DocumentItem
+              key={doc.id}
+              document={doc}
+              onPreview={handlePreview}
+            />
+          ))}
+        </div>
+
+        {data.totalPages > 1 && (
+          <div className="mt-4 flex items-center justify-center gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page <= 1}
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            >
+              이전
+            </button>
+            <span className="text-xs text-zinc-500 dark:text-zinc-400">
+              {page} / {data.totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(data.totalPages, p + 1))}
+              disabled={page >= data.totalPages}
+              className="rounded-lg px-3 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800"
+            >
+              다음
+            </button>
+          </div>
+        )}
+      </div>
+
+      {preview && (
+        <DocumentPreviewModal
+          documentId={preview.id}
+          contentType={preview.contentType}
+          onClose={() => setPreview(null)}
+        />
+      )}
+    </>
+  )
+}
+
+export { DocumentList }

--- a/src/components/library/DocumentPreviewModal.tsx
+++ b/src/components/library/DocumentPreviewModal.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Icon } from '@iconify/react'
+import { fetchDocumentDetail } from '@/api/library'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+
+interface DocumentPreviewModalProps {
+  documentId: number
+  contentType: string
+  onClose: () => void
+}
+
+function DocumentPreviewModal({
+  documentId,
+  contentType,
+  onClose,
+}: DocumentPreviewModalProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['library', 'documents', documentId, 'detail'],
+    queryFn: () => fetchDocumentDetail(documentId),
+    select: (res) => res.data,
+  })
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  const previewUrl = data?.preview_url
+
+  function renderPreview() {
+    if (isLoading) {
+      return (
+        <div className="flex h-full items-center justify-center">
+          <LoadingSpinner size="lg" />
+        </div>
+      )
+    }
+
+    if (error || !previewUrl) {
+      return (
+        <div className="flex h-full items-center justify-center text-zinc-400">
+          미리보기를 불러올 수 없습니다
+        </div>
+      )
+    }
+
+    if (contentType === 'application/pdf') {
+      return (
+        <iframe
+          src={previewUrl}
+          title="Document preview"
+          className="h-full w-full"
+        />
+      )
+    }
+
+    if (contentType.startsWith('image/')) {
+      return (
+        <div className="flex h-full items-center justify-center p-4">
+          <img
+            src={previewUrl}
+            alt="Preview"
+            className="max-h-full max-w-full object-contain"
+          />
+        </div>
+      )
+    }
+
+    if (contentType.startsWith('text/')) {
+      return (
+        <iframe
+          src={previewUrl}
+          title="Text preview"
+          className="h-full w-full bg-white"
+        />
+      )
+    }
+
+    return (
+      <div className="flex h-full items-center justify-center text-zinc-400">
+        이 파일 형식은 미리보기를 지원하지 않습니다
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      onClick={onClose}
+    >
+      <div
+        className="relative h-[85vh] w-[85vw] max-w-5xl overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-zinc-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
+          <h3 className="truncate text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            {data?.original_filename ?? '미리보기'}
+          </h3>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-300"
+          >
+            <Icon icon="solar:close-circle-linear" width={20} />
+          </button>
+        </div>
+
+        <div className="h-[calc(85vh-48px)]">{renderPreview()}</div>
+      </div>
+    </div>
+  )
+}
+
+export { DocumentPreviewModal }

--- a/src/components/library/DocumentUploadButton.tsx
+++ b/src/components/library/DocumentUploadButton.tsx
@@ -1,0 +1,52 @@
+import { useRef } from 'react'
+import { Icon } from '@iconify/react'
+import { useUploadDocument } from '@/hooks/useUploadDocument'
+import { uploadFileSchema } from '@/schemas/library'
+import { LIBRARY_FILE_EXTENSIONS } from '@/lib/constants'
+
+function DocumentUploadButton() {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { mutate, isPending } = useUploadDocument()
+
+  function handleClick() {
+    inputRef.current?.click()
+  }
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const result = uploadFileSchema.safeParse(file)
+    if (!result.success) {
+      const message = result.error.issues[0]?.message ?? '파일 검증 실패'
+      alert(message)
+      if (inputRef.current) inputRef.current.value = ''
+      return
+    }
+
+    mutate(file)
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={LIBRARY_FILE_EXTENSIONS.join(',')}
+        onChange={handleChange}
+        className="hidden"
+      />
+      <button
+        onClick={handleClick}
+        disabled={isPending}
+        className="flex items-center gap-1.5 rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
+      >
+        <Icon icon="solar:upload-linear" width={16} />
+        업로드
+      </button>
+    </>
+  )
+}
+
+export { DocumentUploadButton }

--- a/src/components/library/DocumentUploadProgress.tsx
+++ b/src/components/library/DocumentUploadProgress.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from 'react'
+import { Icon } from '@iconify/react'
+import { useLibraryStore } from '@/stores/libraryStore'
+import { cn } from '@/lib/utils'
+
+function DocumentUploadProgress() {
+  const uploads = useLibraryStore((s) => s.uploads)
+  const removeUpload = useLibraryStore((s) => s.removeUpload)
+
+  useEffect(() => {
+    const completedIds = uploads
+      .filter((u) => u.status === 'completed')
+      .map((u) => u.id)
+
+    if (completedIds.length === 0) return
+
+    const timers = completedIds.map((id) =>
+      setTimeout(() => removeUpload(id), 3000),
+    )
+
+    return () => timers.forEach(clearTimeout)
+  }, [uploads, removeUpload])
+
+  if (uploads.length === 0) return null
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex w-80 flex-col gap-2">
+      {uploads.map((upload) => (
+        <div
+          key={upload.id}
+          className="rounded-lg border border-zinc-200 bg-white p-3 shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
+        >
+          <div className="mb-1.5 flex items-center justify-between">
+            <span className="max-w-[200px] truncate text-xs font-medium text-zinc-700 dark:text-zinc-300">
+              {upload.filename}
+            </span>
+            <div className="flex items-center gap-1">
+              {upload.status === 'uploading' && (
+                <span className="text-xs text-zinc-500">{upload.progress}%</span>
+              )}
+              {upload.status === 'completed' && (
+                <Icon
+                  icon="solar:check-circle-bold"
+                  width={16}
+                  className="text-emerald-500"
+                />
+              )}
+              {upload.status === 'failed' && (
+                <Icon
+                  icon="solar:close-circle-bold"
+                  width={16}
+                  className="text-red-500"
+                />
+              )}
+            </div>
+          </div>
+
+          <div className="h-1.5 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-700">
+            <div
+              className={cn(
+                'h-full rounded-full transition-all duration-300',
+                upload.status === 'failed'
+                  ? 'bg-red-500'
+                  : upload.status === 'completed'
+                    ? 'bg-emerald-500'
+                    : 'bg-blue-500',
+              )}
+              style={{ width: `${upload.progress}%` }}
+            />
+          </div>
+
+          {upload.status === 'failed' && upload.error && (
+            <p className="mt-1 text-xs text-red-500">{upload.error}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export { DocumentUploadProgress }

--- a/src/components/library/LibraryHeader.tsx
+++ b/src/components/library/LibraryHeader.tsx
@@ -1,0 +1,53 @@
+import { DocumentFilterToggle } from './DocumentFilterToggle'
+import { DocumentUploadButton } from './DocumentUploadButton'
+import { useStorageUsage } from '@/hooks/useLibraryDocuments'
+import { formatFileSize } from '@/lib/format'
+import { cn } from '@/lib/utils'
+
+function LibraryHeader() {
+  const { data: storage } = useStorageUsage()
+
+  const usagePercent = storage
+    ? Math.round((storage.used_bytes / storage.max_bytes) * 100)
+    : 0
+
+  return (
+    <div className="border-b border-zinc-200 px-4 py-3 dark:border-zinc-700">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+          라이브러리
+        </h1>
+        <div className="flex items-center gap-2">
+          <DocumentFilterToggle />
+          <DocumentUploadButton />
+        </div>
+      </div>
+
+      {storage && (
+        <div className="mt-2">
+          <div className="flex items-center justify-between text-[11px] text-zinc-400 dark:text-zinc-500">
+            <span>
+              {formatFileSize(storage.used_bytes)} / {formatFileSize(storage.max_bytes)} 사용 중
+            </span>
+            <span>{storage.document_count}개 문서</span>
+          </div>
+          <div className="mt-1 h-1 overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-700">
+            <div
+              className={cn(
+                'h-full rounded-full transition-all duration-300',
+                usagePercent >= 90
+                  ? 'bg-red-500'
+                  : usagePercent >= 70
+                    ? 'bg-amber-500'
+                    : 'bg-blue-500',
+              )}
+              style={{ width: `${Math.min(usagePercent, 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export { LibraryHeader }

--- a/src/components/sidebar/Sidebar.test.tsx
+++ b/src/components/sidebar/Sidebar.test.tsx
@@ -19,6 +19,7 @@ vi.mock('react-router', async () => {
     ...actual,
     useNavigate: () => mockNavigate,
     useParams: () => ({ conversationId: undefined }),
+    useLocation: () => ({ pathname: '/chat' }),
   }
 })
 
@@ -76,9 +77,16 @@ describe('Sidebar', () => {
     expect(aside.className).toContain('translate-x-0')
   })
 
-  it('disables library and agents buttons', () => {
+  it('library button is enabled and agents button is disabled', () => {
     renderWithProviders(<Sidebar />)
-    expect(screen.getByText('라이브러리').closest('button')).toBeDisabled()
+    expect(screen.getByText('라이브러리').closest('button')).not.toBeDisabled()
     expect(screen.getByText('에이전트').closest('button')).toBeDisabled()
+  })
+
+  it('navigates to /library on library click', async () => {
+    const { user } = renderWithProviders(<Sidebar />)
+
+    await user.click(screen.getByText('라이브러리'))
+    expect(mockNavigate).toHaveBeenCalledWith('/library')
   })
 })

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router'
+import { useNavigate, useLocation } from 'react-router'
 import { Icon } from '@iconify/react'
 import { SidebarConversationList } from './SidebarConversationList'
 import { useSidebarStore } from '@/stores/sidebarStore'
@@ -6,10 +6,18 @@ import { cn } from '@/lib/utils'
 
 function Sidebar() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { isOpen, close } = useSidebarStore()
 
   function handleNewChat() {
     navigate('/chat')
+    if (window.innerWidth < 1024) {
+      close()
+    }
+  }
+
+  function handleLibrary() {
+    navigate('/library')
     if (window.innerWidth < 1024) {
       close()
     }
@@ -52,12 +60,12 @@ function Sidebar() {
 
         {/* Navigation sections */}
         <nav className="flex flex-1 flex-col overflow-hidden">
-          {/* Placeholder links */}
           <div className="space-y-0.5 px-3 pb-2">
             <SidebarNavItem
               icon="solar:library-linear"
               label="라이브러리"
-              disabled
+              active={location.pathname === '/library'}
+              onClick={handleLibrary}
             />
             <SidebarNavItem
               icon="solar:robot-bold"
@@ -87,15 +95,25 @@ function SidebarNavItem({
   icon,
   label,
   disabled,
+  active,
+  onClick,
 }: {
   icon: string
   label: string
   disabled?: boolean
+  active?: boolean
+  onClick?: () => void
 }) {
   return (
     <button
       disabled={disabled}
-      className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm text-zinc-600 transition-colors hover:bg-zinc-50 disabled:cursor-not-allowed disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800"
+      onClick={onClick}
+      className={cn(
+        'flex w-full items-center gap-2 rounded-lg px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+        active
+          ? 'bg-zinc-100 font-medium text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100'
+          : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-400 dark:hover:bg-zinc-800',
+      )}
     >
       <Icon icon={icon} width={18} />
       {label}

--- a/src/hooks/useLibraryDocuments.test.ts
+++ b/src/hooks/useLibraryDocuments.test.ts
@@ -1,0 +1,57 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useLibraryDocuments, useStorageUsage } from './useLibraryDocuments'
+import { useLibraryStore } from '@/stores/libraryStore'
+import { AllProviders } from '@/test/utils'
+
+vi.mock('@/api/library', () => ({
+  fetchDocuments: vi.fn().mockResolvedValue({
+    status: 200,
+    message: 'ok',
+    data: {
+      documents: [
+        { id: 1, original_filename: 'test.pdf', status: 'active' },
+        { id: 2, original_filename: 'doc.txt', status: 'archived' },
+      ],
+      total: 2,
+      page: 1,
+      size: 20,
+    },
+  }),
+  fetchStorageUsage: vi.fn().mockResolvedValue({
+    status: 200,
+    message: 'ok',
+    data: { used_bytes: 5242880, max_bytes: 104857600, document_count: 2 },
+  }),
+}))
+
+describe('useLibraryDocuments', () => {
+  beforeEach(() => {
+    useLibraryStore.setState({ includeArchived: false })
+  })
+
+  it('문서 목록을 조회하고 totalPages를 계산한다', async () => {
+    const { result } = renderHook(() => useLibraryDocuments(1), {
+      wrapper: AllProviders,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.documents).toHaveLength(2)
+    expect(result.current.data?.total).toBe(2)
+    expect(result.current.data?.totalPages).toBe(1)
+  })
+})
+
+describe('useStorageUsage', () => {
+  it('스토리지 사용량을 조회한다', async () => {
+    const { result } = renderHook(() => useStorageUsage(), {
+      wrapper: AllProviders,
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(result.current.data?.used_bytes).toBe(5242880)
+    expect(result.current.data?.max_bytes).toBe(104857600)
+    expect(result.current.data?.document_count).toBe(2)
+  })
+})

--- a/src/hooks/useLibraryDocuments.ts
+++ b/src/hooks/useLibraryDocuments.ts
@@ -3,6 +3,8 @@ import { fetchDocuments, fetchStorageUsage } from '@/api/library'
 import { useLibraryStore } from '@/stores/libraryStore'
 import { LIBRARY_PAGE_SIZE } from '@/lib/constants'
 
+const SUMMARY_POLL_INTERVAL = 5000
+
 function useLibraryDocuments(page: number = 1) {
   const includeArchived = useLibraryStore((s) => s.includeArchived)
 
@@ -23,6 +25,14 @@ function useLibraryDocuments(page: number = 1) {
         totalPages: Math.ceil(listData.total / listData.size),
         page: listData.page,
       }
+    },
+    refetchInterval: (query) => {
+      const docs = query.state.data?.data?.documents
+      if (!docs) return false
+      const hasPending = docs.some(
+        (d) => d.summary_status === 'pending' || d.summary_status === 'processing',
+      )
+      return hasPending ? SUMMARY_POLL_INTERVAL : false
     },
   })
 }

--- a/src/hooks/useLibraryDocuments.ts
+++ b/src/hooks/useLibraryDocuments.ts
@@ -1,0 +1,39 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchDocuments, fetchStorageUsage } from '@/api/library'
+import { useLibraryStore } from '@/stores/libraryStore'
+import { LIBRARY_PAGE_SIZE } from '@/lib/constants'
+
+function useLibraryDocuments(page: number = 1) {
+  const includeArchived = useLibraryStore((s) => s.includeArchived)
+
+  return useQuery({
+    queryKey: ['library', 'documents', { page, includeArchived }],
+    queryFn: () =>
+      fetchDocuments({
+        page,
+        size: LIBRARY_PAGE_SIZE,
+        include_archived: includeArchived,
+      }),
+    select: (data) => {
+      const listData = data.data
+      if (!listData) return { documents: [], total: 0, totalPages: 0, page: 1 }
+      return {
+        documents: listData.documents,
+        total: listData.total,
+        totalPages: Math.ceil(listData.total / listData.size),
+        page: listData.page,
+      }
+    },
+  })
+}
+
+function useStorageUsage() {
+  return useQuery({
+    queryKey: ['library', 'storage'],
+    queryFn: fetchStorageUsage,
+    staleTime: 30 * 1000,
+    select: (data) => data.data,
+  })
+}
+
+export { useLibraryDocuments, useStorageUsage }

--- a/src/hooks/useLibraryMutations.test.ts
+++ b/src/hooks/useLibraryMutations.test.ts
@@ -1,0 +1,63 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useUpdateDocumentStatus, useDeleteDocument } from './useLibraryMutations'
+import { AllProviders } from '@/test/utils'
+
+const mockUpdateDocumentStatus = vi.fn()
+const mockDeleteDocument = vi.fn()
+
+vi.mock('@/api/library', () => ({
+  updateDocumentStatus: (...args: unknown[]) => mockUpdateDocumentStatus(...args),
+  deleteDocument: (...args: unknown[]) => mockDeleteDocument(...args),
+}))
+
+describe('useUpdateDocumentStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('문서 상태를 변경한다', async () => {
+    mockUpdateDocumentStatus.mockResolvedValue({
+      status: 200,
+      data: { id: 1, status: 'archived' },
+    })
+
+    const { result } = renderHook(() => useUpdateDocumentStatus(), {
+      wrapper: AllProviders,
+    })
+
+    await act(async () => {
+      result.current.mutate({ id: 1, data: { status: 'archived' } })
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockUpdateDocumentStatus).toHaveBeenCalledWith(1, {
+      status: 'archived',
+    })
+  })
+})
+
+describe('useDeleteDocument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('문서를 삭제한다', async () => {
+    mockDeleteDocument.mockResolvedValue({
+      status: 200,
+      data: null,
+    })
+
+    const { result } = renderHook(() => useDeleteDocument(), {
+      wrapper: AllProviders,
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    expect(mockDeleteDocument).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/hooks/useLibraryMutations.ts
+++ b/src/hooks/useLibraryMutations.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateDocumentStatus, deleteDocument } from '@/api/library'
+import type { UpdateStatusRequest } from '@/types/library'
+
+function useUpdateDocumentStatus() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: UpdateStatusRequest }) =>
+      updateDocumentStatus(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['library', 'documents'] })
+    },
+  })
+}
+
+function useDeleteDocument() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => deleteDocument(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['library', 'documents'] })
+      queryClient.invalidateQueries({ queryKey: ['library', 'storage'] })
+    },
+  })
+}
+
+export { useUpdateDocumentStatus, useDeleteDocument }

--- a/src/hooks/useUploadDocument.test.ts
+++ b/src/hooks/useUploadDocument.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useUploadDocument } from './useUploadDocument'
+import { useLibraryStore } from '@/stores/libraryStore'
+import { AllProviders } from '@/test/utils'
+
+const mockUploadDocument = vi.fn()
+
+vi.mock('@/api/library', () => ({
+  uploadDocument: (...args: unknown[]) => mockUploadDocument(...args),
+}))
+
+describe('useUploadDocument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useLibraryStore.setState({ uploads: [] })
+  })
+
+  it('업로드 성공 시 스토어에 업로드를 추가하고 completed로 갱신한다', async () => {
+    mockUploadDocument.mockResolvedValue({
+      status: 201,
+      data: { id: 1, original_filename: 'test.pdf' },
+    })
+
+    const { result } = renderHook(() => useUploadDocument(), {
+      wrapper: AllProviders,
+    })
+
+    const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+
+    await act(async () => {
+      result.current.mutate(file)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+    const uploads = useLibraryStore.getState().uploads
+    expect(uploads).toHaveLength(1)
+    expect(uploads[0].status).toBe('completed')
+    expect(uploads[0].progress).toBe(100)
+  })
+
+  it('업로드 실패 시 스토어에 failed 상태를 설정한다', async () => {
+    mockUploadDocument.mockRejectedValue(new Error('Upload failed'))
+
+    const { result } = renderHook(() => useUploadDocument(), {
+      wrapper: AllProviders,
+    })
+
+    const file = new File(['test'], 'test.pdf', { type: 'application/pdf' })
+
+    await act(async () => {
+      result.current.mutate(file)
+    })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+
+    const uploads = useLibraryStore.getState().uploads
+    expect(uploads).toHaveLength(1)
+    expect(uploads[0].status).toBe('failed')
+    expect(uploads[0].error).toBe('Upload failed')
+  })
+})

--- a/src/hooks/useUploadDocument.ts
+++ b/src/hooks/useUploadDocument.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { uploadDocument } from '@/api/library'
+import { useLibraryStore } from '@/stores/libraryStore'
+
+function useUploadDocument() {
+  const queryClient = useQueryClient()
+  const { addUpload, updateUpload } = useLibraryStore.getState()
+
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const fileId = crypto.randomUUID()
+
+      addUpload({
+        id: fileId,
+        filename: file.name,
+        progress: 0,
+        status: 'uploading',
+      })
+
+      try {
+        const result = await uploadDocument(file, (progress) => {
+          updateUpload(fileId, { progress })
+        })
+
+        updateUpload(fileId, { progress: 100, status: 'completed' })
+
+        return result
+      } catch (error) {
+        updateUpload(fileId, {
+          status: 'failed',
+          error: error instanceof Error ? error.message : '업로드 실패',
+        })
+        throw error
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['library', 'documents'] })
+      queryClient.invalidateQueries({ queryKey: ['library', 'storage'] })
+    },
+  })
+}
+
+export { useUploadDocument }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -28,3 +28,38 @@ export const ACCEPTED_IMAGE_TYPES = [
 ] as const
 
 export const MAX_IMAGE_SIZE = 10 * 1024 * 1024
+
+export const LIBRARY_PAGE_SIZE = 20
+
+export const LIBRARY_ACCEPTED_FILE_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+] as const
+
+export const LIBRARY_FILE_EXTENSIONS = [
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.gif',
+  '.webp',
+  '.pdf',
+  '.txt',
+  '.md',
+] as const
+
+export const LIBRARY_MAX_FILE_SIZE = 10 * 1024 * 1024
+
+export const PREVIEWABLE_CONTENT_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'text/plain',
+  'text/markdown',
+] as const

--- a/src/pages/Library.test.tsx
+++ b/src/pages/Library.test.tsx
@@ -1,0 +1,68 @@
+import { screen, waitFor } from '@testing-library/react'
+import { renderWithProviders } from '@/test/utils'
+import { Library } from './Library'
+
+vi.mock('@/api/library', () => ({
+  fetchDocuments: vi.fn().mockResolvedValue({
+    status: 200,
+    message: 'ok',
+    data: {
+      documents: [
+        {
+          id: 1,
+          original_filename: 'report.pdf',
+          content_type: 'application/pdf',
+          file_size: 1048576,
+          status: 'active',
+          summary: 'A quarterly report',
+          summary_status: 'completed',
+          created_at: '2025-01-01T00:00:00Z',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 20,
+    },
+  }),
+  fetchStorageUsage: vi.fn().mockResolvedValue({
+    status: 200,
+    message: 'ok',
+    data: { used_bytes: 1048576, max_bytes: 104857600, document_count: 1 },
+  }),
+  fetchDocumentDetail: vi.fn(),
+  uploadDocument: vi.fn(),
+}))
+
+describe('Library Page', () => {
+  it('라이브러리 헤더와 문서 목록을 렌더링한다', async () => {
+    renderWithProviders(<Library />)
+
+    expect(screen.getByText('라이브러리')).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.getByText('report.pdf')).toBeInTheDocument()
+    })
+  })
+
+  it('스토리지 사용량을 표시한다', async () => {
+    renderWithProviders(<Library />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/사용 중/)).toBeInTheDocument()
+    })
+  })
+
+  it('필터 토글 버튼을 표시한다', () => {
+    renderWithProviders(<Library />)
+
+    expect(screen.getByText('활성')).toBeInTheDocument()
+    expect(screen.getByText('전체')).toBeInTheDocument()
+  })
+
+  it('업로드 버튼을 표시한다', () => {
+    renderWithProviders(<Library />)
+
+    expect(screen.getByText('업로드')).toBeInTheDocument()
+  })
+})

--- a/src/pages/Library.tsx
+++ b/src/pages/Library.tsx
@@ -1,0 +1,15 @@
+import { LibraryHeader } from '@/components/library/LibraryHeader'
+import { DocumentList } from '@/components/library/DocumentList'
+import { DocumentUploadProgress } from '@/components/library/DocumentUploadProgress'
+
+function Library() {
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <LibraryHeader />
+      <DocumentList />
+      <DocumentUploadProgress />
+    </div>
+  )
+}
+
+export { Library }

--- a/src/schemas/library.test.ts
+++ b/src/schemas/library.test.ts
@@ -1,0 +1,86 @@
+import { uploadFileSchema, updateStatusSchema } from './library'
+
+describe('uploadFileSchema', () => {
+  function createFile(
+    name: string,
+    size: number,
+    type: string,
+  ): File {
+    const buffer = new ArrayBuffer(size)
+    return new File([buffer], name, { type })
+  }
+
+  it('유효한 PDF 파일을 통과시킨다', () => {
+    const file = createFile('doc.pdf', 1024, 'application/pdf')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(true)
+  })
+
+  it('유효한 이미지 파일을 통과시킨다', () => {
+    const file = createFile('photo.jpg', 2048, 'image/jpeg')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(true)
+  })
+
+  it('유효한 텍스트 파일을 통과시킨다', () => {
+    const file = createFile('note.txt', 512, 'text/plain')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(true)
+  })
+
+  it('유효한 마크다운 파일을 통과시킨다', () => {
+    const file = createFile('readme.md', 256, 'text/markdown')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(true)
+  })
+
+  it('10MB 초과 파일을 거부한다', () => {
+    const file = createFile('big.pdf', 11 * 1024 * 1024, 'application/pdf')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(false)
+  })
+
+  it('지원하지 않는 파일 타입을 거부한다', () => {
+    const file = createFile('doc.exe', 1024, 'application/octet-stream')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(false)
+  })
+
+  it('File이 아닌 값을 거부한다', () => {
+    const result = uploadFileSchema.safeParse('not-a-file')
+    expect(result.success).toBe(false)
+  })
+
+  it('정확히 10MB 파일을 통과시킨다', () => {
+    const file = createFile('exact.pdf', 10 * 1024 * 1024, 'application/pdf')
+    const result = uploadFileSchema.safeParse(file)
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('updateStatusSchema', () => {
+  it('active 상태를 통과시킨다', () => {
+    const result = updateStatusSchema.safeParse({ status: 'active' })
+    expect(result.success).toBe(true)
+  })
+
+  it('archived 상태를 통과시킨다', () => {
+    const result = updateStatusSchema.safeParse({ status: 'archived' })
+    expect(result.success).toBe(true)
+  })
+
+  it('잘못된 상태 값을 거부한다', () => {
+    const result = updateStatusSchema.safeParse({ status: 'deleted' })
+    expect(result.success).toBe(false)
+  })
+
+  it('빈 문자열을 거부한다', () => {
+    const result = updateStatusSchema.safeParse({ status: '' })
+    expect(result.success).toBe(false)
+  })
+
+  it('status 필드 누락을 거부한다', () => {
+    const result = updateStatusSchema.safeParse({})
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/schemas/library.ts
+++ b/src/schemas/library.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod/v4'
+import {
+  LIBRARY_ACCEPTED_FILE_TYPES,
+  LIBRARY_MAX_FILE_SIZE,
+} from '@/lib/constants'
+
+const uploadFileSchema = z
+  .instanceof(File)
+  .refine((file) => file.size <= LIBRARY_MAX_FILE_SIZE, {
+    message: '파일 크기는 10MB 이하여야 합니다',
+  })
+  .refine(
+    (file) =>
+      (LIBRARY_ACCEPTED_FILE_TYPES as readonly string[]).includes(file.type),
+    { message: '지원하지 않는 파일 형식입니다' },
+  )
+
+const updateStatusSchema = z.object({
+  status: z.enum(['active', 'archived']),
+})
+
+type UpdateStatusFormData = z.infer<typeof updateStatusSchema>
+
+export { uploadFileSchema, updateStatusSchema }
+export type { UpdateStatusFormData }

--- a/src/stores/libraryStore.test.ts
+++ b/src/stores/libraryStore.test.ts
@@ -1,0 +1,101 @@
+import { useLibraryStore } from './libraryStore'
+import type { UploadProgress } from '@/types/library'
+
+const mockUpload: UploadProgress = {
+  id: 'upload-1',
+  filename: 'test.pdf',
+  progress: 0,
+  status: 'uploading',
+}
+
+describe('libraryStore', () => {
+  beforeEach(() => {
+    useLibraryStore.setState({
+      includeArchived: false,
+      uploads: [],
+    })
+  })
+
+  it('초기 상태가 올바르다', () => {
+    const state = useLibraryStore.getState()
+    expect(state.includeArchived).toBe(false)
+    expect(state.uploads).toEqual([])
+  })
+
+  describe('includeArchived', () => {
+    it('toggleArchived가 상태를 토글한다', () => {
+      useLibraryStore.getState().toggleArchived()
+      expect(useLibraryStore.getState().includeArchived).toBe(true)
+
+      useLibraryStore.getState().toggleArchived()
+      expect(useLibraryStore.getState().includeArchived).toBe(false)
+    })
+
+    it('setIncludeArchived가 값을 직접 설정한다', () => {
+      useLibraryStore.getState().setIncludeArchived(true)
+      expect(useLibraryStore.getState().includeArchived).toBe(true)
+
+      useLibraryStore.getState().setIncludeArchived(false)
+      expect(useLibraryStore.getState().includeArchived).toBe(false)
+    })
+  })
+
+  describe('uploads', () => {
+    it('addUpload이 업로드를 추가한다', () => {
+      useLibraryStore.getState().addUpload(mockUpload)
+      expect(useLibraryStore.getState().uploads).toHaveLength(1)
+      expect(useLibraryStore.getState().uploads[0]).toEqual(mockUpload)
+    })
+
+    it('updateUpload이 특정 업로드를 갱신한다', () => {
+      useLibraryStore.getState().addUpload(mockUpload)
+      useLibraryStore.getState().updateUpload('upload-1', { progress: 50 })
+
+      const upload = useLibraryStore.getState().uploads[0]
+      expect(upload.progress).toBe(50)
+      expect(upload.filename).toBe('test.pdf')
+    })
+
+    it('updateUpload이 존재하지 않는 id를 무시한다', () => {
+      useLibraryStore.getState().addUpload(mockUpload)
+      useLibraryStore.getState().updateUpload('nonexistent', { progress: 99 })
+
+      expect(useLibraryStore.getState().uploads[0].progress).toBe(0)
+    })
+
+    it('removeUpload이 특정 업로드를 제거한다', () => {
+      useLibraryStore.getState().addUpload(mockUpload)
+      useLibraryStore.getState().addUpload({
+        ...mockUpload,
+        id: 'upload-2',
+        filename: 'other.pdf',
+      })
+
+      useLibraryStore.getState().removeUpload('upload-1')
+      expect(useLibraryStore.getState().uploads).toHaveLength(1)
+      expect(useLibraryStore.getState().uploads[0].id).toBe('upload-2')
+    })
+
+    it('clearCompletedUploads가 완료된 업로드만 제거한다', () => {
+      useLibraryStore.getState().addUpload(mockUpload)
+      useLibraryStore.getState().addUpload({
+        id: 'upload-2',
+        filename: 'done.pdf',
+        progress: 100,
+        status: 'completed',
+      })
+      useLibraryStore.getState().addUpload({
+        id: 'upload-3',
+        filename: 'fail.pdf',
+        progress: 30,
+        status: 'failed',
+      })
+
+      useLibraryStore.getState().clearCompletedUploads()
+
+      const uploads = useLibraryStore.getState().uploads
+      expect(uploads).toHaveLength(2)
+      expect(uploads.map((u) => u.id)).toEqual(['upload-1', 'upload-3'])
+    })
+  })
+})

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand'
+import type { UploadProgress } from '@/types/library'
+
+interface LibraryState {
+  includeArchived: boolean
+  uploads: UploadProgress[]
+
+  toggleArchived: () => void
+  setIncludeArchived: (value: boolean) => void
+  addUpload: (upload: UploadProgress) => void
+  updateUpload: (id: string, updates: Partial<UploadProgress>) => void
+  removeUpload: (id: string) => void
+  clearCompletedUploads: () => void
+}
+
+export const useLibraryStore = create<LibraryState>()((set) => ({
+  includeArchived: false,
+  uploads: [],
+
+  toggleArchived: () =>
+    set((state) => ({ includeArchived: !state.includeArchived })),
+
+  setIncludeArchived: (value: boolean) =>
+    set({ includeArchived: value }),
+
+  addUpload: (upload: UploadProgress) =>
+    set((state) => ({ uploads: [...state.uploads, upload] })),
+
+  updateUpload: (id: string, updates: Partial<UploadProgress>) =>
+    set((state) => ({
+      uploads: state.uploads.map((u) =>
+        u.id === id ? { ...u, ...updates } : u,
+      ),
+    })),
+
+  removeUpload: (id: string) =>
+    set((state) => ({
+      uploads: state.uploads.filter((u) => u.id !== id),
+    })),
+
+  clearCompletedUploads: () =>
+    set((state) => ({
+      uploads: state.uploads.filter((u) => u.status !== 'completed'),
+    })),
+}))

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -1,0 +1,47 @@
+export interface LibraryDocument {
+  id: number
+  original_filename: string
+  content_type: string
+  file_size: number
+  status: 'active' | 'archived'
+  summary: string | null
+  summary_status: 'pending' | 'processing' | 'completed' | 'failed'
+  created_at: string
+  updated_at: string
+}
+
+export interface LibraryDocumentDetail extends LibraryDocument {
+  download_url: string
+  preview_url: string
+}
+
+export interface LibraryDocumentListResponse {
+  documents: LibraryDocument[]
+  total: number
+  page: number
+  size: number
+}
+
+export interface StorageUsage {
+  used_bytes: number
+  max_bytes: number
+  document_count: number
+}
+
+export interface UpdateStatusRequest {
+  status: 'active' | 'archived'
+}
+
+export interface LibraryDocumentListParams {
+  page?: number
+  size?: number
+  include_archived?: boolean
+}
+
+export interface UploadProgress {
+  id: string
+  filename: string
+  progress: number
+  status: 'uploading' | 'completed' | 'failed'
+  error?: string
+}


### PR DESCRIPTION
## Summary
- BE 문서 라이브러리 API 8개 엔드포인트에 대응하는 FE `/library` 페이지 구현
- 사이드바 "라이브러리" 버튼 활성화 및 라우팅 연결

## Changes
### New Files
| File | Description |
|------|-------------|
| `src/types/library.ts` | LibraryDocument, StorageUsage 등 타입 정의 |
| `src/schemas/library.ts` | Zod 파일 검증 및 상태 스키마 |
| `src/api/library.ts` | 6개 API 함수 (XHR 업로드 진행률 포함) |
| `src/stores/libraryStore.ts` | Zustand 스토어 (필터, 업로드 진행률) |
| `src/hooks/useLibraryDocuments.ts` | React Query 문서 목록/스토리지 훅 |
| `src/hooks/useUploadDocument.ts` | 파일 업로드 mutation 훅 |
| `src/hooks/useLibraryMutations.ts` | 상태변경/삭제 mutation 훅 |
| `src/components/library/DocumentFilterToggle.tsx` | 활성/전체 필터 토글 |
| `src/components/library/DocumentUploadButton.tsx` | 파일 업로드 버튼 + Zod 검증 |
| `src/components/library/DocumentUploadProgress.tsx` | 업로드 진행률 floating toast |
| `src/components/library/DocumentPreviewModal.tsx` | PDF/이미지/텍스트 미리보기 모달 |
| `src/components/library/DocumentItem.tsx` | 문서 항목 (아이콘, 뱃지, hover 액션) |
| `src/components/library/LibraryHeader.tsx` | 제목, 필터, 업로드, 스토리지 용량 바 |
| `src/components/library/DocumentList.tsx` | 문서 목록 + 페이지네이션 + 빈 상태 |
| `src/pages/Library.tsx` | 라이브러리 페이지 |

### Modified Files
| File | Changes |
|------|---------|
| `src/lib/constants.ts` | 라이브러리 상수 추가 (파일타입, 크기 제한, 페이지 크기) |
| `src/App.tsx` | `/library` 라우트 추가 (ProtectedRoute > AppLayout 내) |
| `src/components/sidebar/Sidebar.tsx` | "라이브러리" 버튼 활성화, active 스타일, useLocation 추가 |
| `src/components/sidebar/Sidebar.test.tsx` | 라이브러리 버튼 enabled 테스트, 네비게이션 테스트 추가 |

## Test Plan
- [x] 스키마 테스트 13개 통과 (uploadFileSchema, updateStatusSchema)
- [x] API 테스트 9개 통과 (ky mock + XHR mock)
- [x] 스토어 테스트 8개 통과 (libraryStore)
- [x] 훅 테스트 6개 통과 (useLibraryDocuments, useUploadDocument, useLibraryMutations)
- [x] 페이지 테스트 4개 통과 (Library)
- [x] 사이드바 테스트 8개 통과 (Sidebar 기존 + 신규)
- [x] TypeScript --noEmit 통과
- [x] 총 48개 테스트 전체 통과

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)