### PR TITLE
feat(library): add multi-upload, bulk delete, and summary status spinner

### DIFF
--- a/src/api/library.test.ts
+++ b/src/api/library.test.ts
@@ -14,9 +14,9 @@ const mockDelete = vi.fn(() => ({ json: mockJson }))
 
 vi.mock('./client', () => ({
   apiClient: {
-    get: (...args: unknown[]) => mockGet(...args),
-    patch: (...args: unknown[]) => mockPatch(...args),
-    delete: (...args: unknown[]) => mockDelete(...args),
+    get: (...args: unknown[]) => mockGet(...(args as [])),
+    patch: (...args: unknown[]) => mockPatch(...(args as [])),
+    delete: (...args: unknown[]) => mockDelete(...(args as [])),
   },
 }))
 

--- a/src/components/library/BulkActionBar.tsx
+++ b/src/components/library/BulkActionBar.tsx
@@ -1,0 +1,52 @@
+import { Icon } from '@iconify/react'
+import { useLibraryStore } from '@/stores/libraryStore'
+import { useBulkDeleteDocuments } from '@/hooks/useBulkDeleteDocuments'
+
+function BulkActionBar() {
+  const selectedIds = useLibraryStore((s) => s.selectedIds)
+  const clearSelection = useLibraryStore((s) => s.clearSelection)
+  const { isDeleting, completed, total, bulkDelete } = useBulkDeleteDocuments()
+
+  const count = selectedIds.size
+
+  if (count === 0) return null
+
+  function handleDelete() {
+    const confirmed = window.confirm(
+      `선택한 ${count}개의 문서를 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.`,
+    )
+    if (!confirmed) return
+    bulkDelete(Array.from(selectedIds))
+  }
+
+  return (
+    <div className="sticky bottom-0 border-t border-zinc-200 bg-white/95 px-4 py-3 backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
+          {isDeleting
+            ? `삭제 중... (${completed}/${total})`
+            : `${count}개 선택됨`}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={clearSelection}
+            disabled={isDeleting}
+            className="rounded-lg px-3 py-1.5 text-xs font-medium text-zinc-600 transition-colors hover:bg-zinc-100 disabled:opacity-50 dark:text-zinc-400 dark:hover:bg-zinc-800"
+          >
+            선택 해제
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={isDeleting}
+            className="flex items-center gap-1.5 rounded-lg bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-red-700 disabled:opacity-50"
+          >
+            <Icon icon="solar:trash-bin-2-linear" width={14} />
+            {isDeleting ? '삭제 중...' : '삭제'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export { BulkActionBar }

--- a/src/components/library/DocumentItem.tsx
+++ b/src/components/library/DocumentItem.tsx
@@ -2,12 +2,15 @@ import { Icon } from '@iconify/react'
 import { cn } from '@/lib/utils'
 import { formatRelativeTime, formatFileSize } from '@/lib/format'
 import { useUpdateDocumentStatus, useDeleteDocument } from '@/hooks/useLibraryMutations'
+import { SummaryStatusBadge } from './SummaryStatusBadge'
 import { API_BASE_URL } from '@/lib/constants'
 import type { LibraryDocument } from '@/types/library'
 
 interface DocumentItemProps {
   document: LibraryDocument
   onPreview: (id: number, contentType: string) => void
+  isSelected?: boolean
+  onToggleSelect?: (id: number) => void
 }
 
 function getFileIcon(contentType: string): string {
@@ -16,12 +19,16 @@ function getFileIcon(contentType: string): string {
   return 'solar:document-linear'
 }
 
-function DocumentItem({ document: doc, onPreview }: DocumentItemProps) {
+function DocumentItem({
+  document: doc,
+  onPreview,
+  isSelected = false,
+  onToggleSelect,
+}: DocumentItemProps) {
   const updateStatus = useUpdateDocumentStatus()
   const deleteDoc = useDeleteDocument()
 
   const isArchived = doc.status === 'archived'
-  const isSummarizing = doc.summary_status === 'pending' || doc.summary_status === 'processing'
 
   function handleDownload() {
     window.open(
@@ -47,6 +54,17 @@ function DocumentItem({ document: doc, onPreview }: DocumentItemProps) {
         isArchived && 'opacity-50',
       )}
     >
+      {onToggleSelect && (
+        <label className="mt-0.5 flex flex-shrink-0 cursor-pointer items-center">
+          <input
+            type="checkbox"
+            checked={isSelected}
+            onChange={() => onToggleSelect(doc.id)}
+            className="h-4 w-4 rounded border-zinc-300 text-zinc-900 focus:ring-zinc-500 dark:border-zinc-600 dark:bg-zinc-700"
+          />
+        </label>
+      )}
+
       <div className="mt-0.5 flex-shrink-0 text-zinc-400 dark:text-zinc-500">
         <Icon icon={getFileIcon(doc.content_type)} width={20} />
       </div>
@@ -61,11 +79,7 @@ function DocumentItem({ document: doc, onPreview }: DocumentItemProps) {
               보관됨
             </span>
           )}
-          {isSummarizing && (
-            <span className="flex-shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
-              요약 중
-            </span>
-          )}
+          <SummaryStatusBadge summaryStatus={doc.summary_status} />
         </div>
 
         {doc.summary && (

--- a/src/components/library/DocumentUploadButton.tsx
+++ b/src/components/library/DocumentUploadButton.tsx
@@ -1,30 +1,28 @@
 import { useRef } from 'react'
 import { Icon } from '@iconify/react'
-import { useUploadDocument } from '@/hooks/useUploadDocument'
-import { uploadFileSchema } from '@/schemas/library'
+import { useMultiFileUpload } from '@/hooks/useMultiFileUpload'
+import { useStorageUsage } from '@/hooks/useLibraryDocuments'
 import { LIBRARY_FILE_EXTENSIONS } from '@/lib/constants'
 
 function DocumentUploadButton() {
   const inputRef = useRef<HTMLInputElement>(null)
-  const { mutate, isPending } = useUploadDocument()
+  const { data: storage } = useStorageUsage()
+
+  const remainingBytes = storage
+    ? storage.max_bytes - storage.used_bytes
+    : Infinity
+
+  const { uploadFiles, isUploading } = useMultiFileUpload({ remainingBytes })
 
   function handleClick() {
     inputRef.current?.click()
   }
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0]
-    if (!file) return
+    const fileList = e.target.files
+    if (!fileList || fileList.length === 0) return
 
-    const result = uploadFileSchema.safeParse(file)
-    if (!result.success) {
-      const message = result.error.issues[0]?.message ?? '파일 검증 실패'
-      alert(message)
-      if (inputRef.current) inputRef.current.value = ''
-      return
-    }
-
-    mutate(file)
+    uploadFiles(Array.from(fileList))
     if (inputRef.current) inputRef.current.value = ''
   }
 
@@ -33,13 +31,14 @@ function DocumentUploadButton() {
       <input
         ref={inputRef}
         type="file"
+        multiple
         accept={LIBRARY_FILE_EXTENSIONS.join(',')}
         onChange={handleChange}
         className="hidden"
       />
       <button
         onClick={handleClick}
-        disabled={isPending}
+        disabled={isUploading}
         className="flex items-center gap-1.5 rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-zinc-800 disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
       >
         <Icon icon="solar:upload-linear" width={16} />

--- a/src/components/library/SummaryStatusBadge.tsx
+++ b/src/components/library/SummaryStatusBadge.tsx
@@ -1,0 +1,76 @@
+import { cn } from '@/lib/utils'
+import type { LibraryDocument } from '@/types/library'
+
+type SummaryStatus = LibraryDocument['summary_status']
+
+interface SummaryStatusBadgeProps {
+  summaryStatus: SummaryStatus
+}
+
+const STATUS_CONFIG: Record<
+  SummaryStatus,
+  { label: string; className: string; showSpinner: boolean }
+> = {
+  pending: {
+    label: '요약 중',
+    className:
+      'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    showSpinner: true,
+  },
+  processing: {
+    label: '요약 중',
+    className:
+      'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400',
+    showSpinner: true,
+  },
+  completed: {
+    label: '사용 가능',
+    className:
+      'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    showSpinner: false,
+  },
+  failed: {
+    label: '사용 불가',
+    className:
+      'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
+    showSpinner: false,
+  },
+}
+
+function SummaryStatusBadge({ summaryStatus }: SummaryStatusBadgeProps) {
+  const config = STATUS_CONFIG[summaryStatus]
+
+  return (
+    <span
+      className={cn(
+        'inline-flex flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium',
+        config.className,
+      )}
+    >
+      {config.showSpinner && (
+        <svg
+          className="h-3 w-3 animate-spin"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+      )}
+      {config.label}
+    </span>
+  )
+}
+
+export { SummaryStatusBadge }

--- a/src/components/shared/Navbar.tsx
+++ b/src/components/shared/Navbar.tsx
@@ -1,4 +1,5 @@
 import { Icon } from '@iconify/react'
+import { Link } from 'react-router'
 import { ThemeToggle } from './ThemeToggle'
 import { UserDropdown } from './UserDropdown'
 import { useSidebarStore } from '@/stores/sidebarStore'
@@ -17,14 +18,14 @@ function Navbar() {
           <Icon icon="solar:hamburger-menu-linear" width={20} />
         </button>
 
-        <div className="flex items-center gap-1.5">
+        <Link to="/chat" className="flex items-center gap-1.5">
           <div className="flex h-7 w-7 items-center justify-center rounded-full bg-zinc-900 dark:bg-zinc-50">
             <div className="h-2.5 w-2.5 rounded-full bg-zinc-50 dark:bg-zinc-900" />
           </div>
           <span className="text-base font-semibold tracking-tight text-zinc-950 dark:text-zinc-50">
             RAG.OS
           </span>
-        </div>
+        </Link>
       </div>
 
       <div className="flex items-center gap-1">

--- a/src/hooks/useBulkDeleteDocuments.ts
+++ b/src/hooks/useBulkDeleteDocuments.ts
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { deleteDocument } from '@/api/library'
+import { useLibraryStore } from '@/stores/libraryStore'
+
+interface BulkDeleteState {
+  isDeleting: boolean
+  completed: number
+  total: number
+}
+
+function useBulkDeleteDocuments() {
+  const queryClient = useQueryClient()
+  const clearSelection = useLibraryStore((s) => s.clearSelection)
+  const [state, setState] = useState<BulkDeleteState>({
+    isDeleting: false,
+    completed: 0,
+    total: 0,
+  })
+
+  async function bulkDelete(ids: number[]) {
+    if (ids.length === 0) return
+
+    setState({ isDeleting: true, completed: 0, total: ids.length })
+
+    const results = await Promise.allSettled(
+      ids.map(async (id) => {
+        const result = await deleteDocument(id)
+        setState((prev) => ({ ...prev, completed: prev.completed + 1 }))
+        return result
+      }),
+    )
+
+    const failedCount = results.filter((r) => r.status === 'rejected').length
+
+    clearSelection()
+    queryClient.invalidateQueries({ queryKey: ['library', 'documents'] })
+    queryClient.invalidateQueries({ queryKey: ['library', 'storage'] })
+
+    setState({ isDeleting: false, completed: 0, total: 0 })
+
+    if (failedCount > 0) {
+      alert(`${ids.length}개 중 ${failedCount}개 삭제에 실패했습니다`)
+    }
+  }
+
+  return { ...state, bulkDelete }
+}
+
+export { useBulkDeleteDocuments }

--- a/src/hooks/useMultiFileUpload.ts
+++ b/src/hooks/useMultiFileUpload.ts
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { uploadDocument } from '@/api/library'
+import { uploadFileSchema } from '@/schemas/library'
+import { useLibraryStore } from '@/stores/libraryStore'
+import { formatFileSize } from '@/lib/format'
+
+interface UseMultiFileUploadOptions {
+  remainingBytes: number
+}
+
+function useMultiFileUpload({ remainingBytes }: UseMultiFileUploadOptions) {
+  const queryClient = useQueryClient()
+  const { addUpload, updateUpload } = useLibraryStore.getState()
+  const [isUploading, setIsUploading] = useState(false)
+
+  async function uploadFiles(files: File[]) {
+    if (files.length === 0) return
+
+    const validFiles: File[] = []
+    for (const file of files) {
+      const result = uploadFileSchema.safeParse(file)
+      if (!result.success) {
+        const fileId = crypto.randomUUID()
+        const message = result.error.issues[0]?.message ?? '파일 검증 실패'
+        addUpload({
+          id: fileId,
+          filename: file.name,
+          progress: 0,
+          status: 'failed',
+          error: message,
+        })
+      } else {
+        validFiles.push(file)
+      }
+    }
+
+    if (validFiles.length === 0) return
+
+    const totalSize = validFiles.reduce((sum, f) => sum + f.size, 0)
+    if (totalSize > remainingBytes) {
+      const exceeded = totalSize - remainingBytes
+      alert(
+        `저장 용량이 부족합니다.\n` +
+          `필요한 용량: ${formatFileSize(totalSize)}\n` +
+          `남은 용량: ${formatFileSize(remainingBytes)}\n` +
+          `초과량: ${formatFileSize(exceeded)}`,
+      )
+      return
+    }
+
+    setIsUploading(true)
+
+    for (const file of validFiles) {
+      const fileId = crypto.randomUUID()
+
+      addUpload({
+        id: fileId,
+        filename: file.name,
+        progress: 0,
+        status: 'uploading',
+      })
+
+      try {
+        await uploadDocument(file, (progress) => {
+          updateUpload(fileId, { progress })
+        })
+        updateUpload(fileId, { progress: 100, status: 'completed' })
+      } catch (error) {
+        updateUpload(fileId, {
+          status: 'failed',
+          error: error instanceof Error ? error.message : '업로드 실패',
+        })
+      }
+    }
+
+    queryClient.invalidateQueries({ queryKey: ['library', 'documents'] })
+    queryClient.invalidateQueries({ queryKey: ['library', 'storage'] })
+    setIsUploading(false)
+  }
+
+  return { uploadFiles, isUploading }
+}
+
+export { useMultiFileUpload }

--- a/src/stores/libraryStore.ts
+++ b/src/stores/libraryStore.ts
@@ -4,6 +4,7 @@ import type { UploadProgress } from '@/types/library'
 interface LibraryState {
   includeArchived: boolean
   uploads: UploadProgress[]
+  selectedIds: Set<number>
 
   toggleArchived: () => void
   setIncludeArchived: (value: boolean) => void
@@ -11,11 +12,15 @@ interface LibraryState {
   updateUpload: (id: string, updates: Partial<UploadProgress>) => void
   removeUpload: (id: string) => void
   clearCompletedUploads: () => void
+  toggleSelection: (id: number) => void
+  selectAll: (ids: number[]) => void
+  clearSelection: () => void
 }
 
 export const useLibraryStore = create<LibraryState>()((set) => ({
   includeArchived: false,
   uploads: [],
+  selectedIds: new Set<number>(),
 
   toggleArchived: () =>
     set((state) => ({ includeArchived: !state.includeArchived })),
@@ -42,4 +47,24 @@ export const useLibraryStore = create<LibraryState>()((set) => ({
     set((state) => ({
       uploads: state.uploads.filter((u) => u.status !== 'completed'),
     })),
+
+  toggleSelection: (id: number) =>
+    set((state) => {
+      const next = new Set(state.selectedIds)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return { selectedIds: next }
+    }),
+
+  selectAll: (ids: number[]) =>
+    set((state) => {
+      const allSelected = ids.every((id) => state.selectedIds.has(id))
+      return { selectedIds: allSelected ? new Set<number>() : new Set(ids) }
+    }),
+
+  clearSelection: () =>
+    set({ selectedIds: new Set<number>() }),
 }))


### PR DESCRIPTION
## Summary
- 라이브러리 다중 파일 업로드(용량 검증 포함), 다중 선택 삭제, 요약 상태 스피너 기능 추가
- Navbar 로고 클릭 시 /chat 이동 개선

## Changes
### New Files
| File | Description |
|------|-------------|
| `src/components/library/SummaryStatusBadge.tsx` | 4가지 요약 상태별 배지 컴포넌트 (pending/processing: amber 스피너, completed: emerald, failed: red) |
| `src/components/library/BulkActionBar.tsx` | 다중 선택 시 하단 액션바 (선택 개수, 삭제 확인 다이얼로그) |
| `src/hooks/useMultiFileUpload.ts` | 다중 파일 Zod 검증 + 남은 용량 비교 + 순차 업로드 훅 |
| `src/hooks/useBulkDeleteDocuments.ts` | Promise.allSettled 기반 다중 삭제 + 진행 상태 추적 훅 |

### Modified Files
| File | Changes |
|------|---------|
| `src/stores/libraryStore.ts` | selectedIds, toggleSelection, selectAll, clearSelection 선택 상태 추가 |
| `src/components/library/DocumentItem.tsx` | 체크박스 추가 + 인라인 배지를 SummaryStatusBadge로 교체 |
| `src/components/library/DocumentList.tsx` | 전체 선택 헤더 + BulkActionBar + 페이지 변경 시 선택 해제 |
| `src/components/library/DocumentUploadButton.tsx` | multiple input + useMultiFileUpload + 용량 검증 |
| `src/components/shared/Navbar.tsx` | 로고를 Link 컴포넌트로 교체 (/chat 이동) |
| `src/api/library.test.ts` | 기존 타입 오류 수정 (spread argument tuple type) |

## Test Plan
- [x] 빌드 성공 확인 (npm run build)
- [ ] 다중 파일 선택 업로드 → 개별 진행률 확인
- [ ] 용량 초과 시 alert 확인 (초과량 표시)
- [ ] 체크박스 선택 → BulkActionBar 표시 → 다중 삭제 확인
- [ ] 요약 중 문서의 스피너 애니메이션 확인
- [ ] 요약 완료/실패 시 배지 변경 확인

Closes heemanglee/langchain-chat#25

🤖 Generated with [Claude Code](https://claude.ai/code)