### PR TITLE
feat(citation): implement RAG citation UI with document selection and source panel

### DIFF
--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -194,6 +194,22 @@ describe('chat API', () => {
       expect(formData.get('message')).toBe('test')
       expect(formData.getAll('images')).toHaveLength(1)
     })
+
+    it('appends selected_document_ids as JSON when provided', async () => {
+      const handlers = {
+        onToken: vi.fn(),
+        onDone: vi.fn(),
+        onError: vi.fn(),
+      }
+
+      await streamChat(
+        { message: 'test', selected_document_ids: [1, 3] },
+        handlers,
+      )
+
+      const formData = mockStreamSSEWithFormData.mock.calls[0][1] as FormData
+      expect(formData.get('selected_document_ids')).toBe('[1,3]')
+    })
   })
 
   describe('streamEditMessage', () => {

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -37,6 +37,7 @@ export interface StreamChatOptions {
   message: string
   conversation_id?: string
   use_web_search?: boolean
+  selected_document_ids?: number[]
   images?: File[]
 }
 
@@ -49,6 +50,12 @@ export async function streamChat(
   formData.append('message', request.message)
   if (request.conversation_id) {
     formData.append('conversation_id', request.conversation_id)
+  }
+  if (request.selected_document_ids && request.selected_document_ids.length > 0) {
+    formData.append(
+      'selected_document_ids',
+      JSON.stringify(request.selected_document_ids),
+    )
   }
   if (request.images) {
     for (const file of request.images) {

--- a/src/api/library.test.ts
+++ b/src/api/library.test.ts
@@ -4,17 +4,20 @@ import {
   updateDocumentStatus,
   deleteDocument,
   fetchStorageUsage,
+  reindexDocument,
   uploadDocument,
 } from './library'
 
 const mockJson = vi.fn()
 const mockGet = vi.fn(() => ({ json: mockJson }))
+const mockPost = vi.fn(() => ({ json: mockJson }))
 const mockPatch = vi.fn(() => ({ json: mockJson }))
 const mockDelete = vi.fn(() => ({ json: mockJson }))
 
 vi.mock('./client', () => ({
   apiClient: {
     get: (...args: unknown[]) => mockGet(...(args as [])),
+    post: (...args: unknown[]) => mockPost(...(args as [])),
     patch: (...args: unknown[]) => mockPatch(...(args as [])),
     delete: (...args: unknown[]) => mockDelete(...(args as [])),
   },
@@ -81,6 +84,18 @@ describe('library API', () => {
       const result = await deleteDocument(1)
 
       expect(mockDelete).toHaveBeenCalledWith('api/v1/library/documents/1')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('reindexDocument', () => {
+    it('문서 재인덱싱을 요청한다', async () => {
+      const response = { status: 200, message: 'ok', data: { id: 1, index_status: 'pending' } }
+      mockJson.mockResolvedValue(response)
+
+      const result = await reindexDocument(1)
+
+      expect(mockPost).toHaveBeenCalledWith('api/v1/library/documents/1/reindex')
       expect(result).toEqual(response)
     })
   })

--- a/src/api/library.ts
+++ b/src/api/library.ts
@@ -43,6 +43,12 @@ export function deleteDocument(id: number): Promise<ApiResponse<null>> {
   return apiClient.delete(`api/v1/library/documents/${id}`).json()
 }
 
+export function reindexDocument(
+  id: number,
+): Promise<ApiResponse<LibraryDocument>> {
+  return apiClient.post(`api/v1/library/documents/${id}/reindex`).json()
+}
+
 export function fetchStorageUsage(): Promise<ApiResponse<StorageUsage>> {
   return apiClient.get('api/v1/library/storage').json()
 }

--- a/src/components/chat/ChatMessage.test.tsx
+++ b/src/components/chat/ChatMessage.test.tsx
@@ -1,7 +1,30 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ChatMessage } from './ChatMessage'
-import type { Message } from '@/types/chat'
+import type { Citation, Message } from '@/types/chat'
+
+const testCitations: Citation[] = [
+  {
+    citation_id: 'lib-1',
+    source_type: 'library',
+    title: 'doc1.pdf',
+    snippet: null,
+    file_id: 1,
+    file_name: 'doc1.pdf',
+    anchors: [
+      {
+        anchor_id: 'a-1',
+        page: 1,
+        line_start: null,
+        line_end: null,
+        start_char: 0,
+        end_char: 10,
+        bbox: null,
+        quote: 'citation',
+      },
+    ],
+  },
+]
 
 function createMessage(overrides: Partial<Message> = {}): Message {
   return {
@@ -61,7 +84,7 @@ describe('ChatMessage', () => {
         message={createMessage({
           role: 'assistant',
           content: '답변',
-          sources: ['doc1.pdf'],
+          sources: testCitations,
         })}
       />,
     )

--- a/src/components/chat/ChatMessage.tsx
+++ b/src/components/chat/ChatMessage.tsx
@@ -1,6 +1,6 @@
 import { UserMessage } from './UserMessage'
 import { AssistantMessage } from './AssistantMessage'
-import type { Message } from '@/types/chat'
+import type { LibraryCitation, Message } from '@/types/chat'
 
 interface ChatMessageProps {
   message: Message
@@ -8,9 +8,22 @@ interface ChatMessageProps {
   onEdit?: (serverId: number, newContent: string) => void
   onRegenerate?: (serverId: number) => void
   isLastAssistant?: boolean
+  activeCitationId?: string | null
+  onOpenLibraryCitation?: (
+    citation: LibraryCitation,
+    anchorId?: string,
+  ) => void
 }
 
-function ChatMessage({ message, usedTools, onEdit, onRegenerate, isLastAssistant }: ChatMessageProps) {
+function ChatMessage({
+  message,
+  usedTools,
+  onEdit,
+  onRegenerate,
+  isLastAssistant,
+  activeCitationId,
+  onOpenLibraryCitation,
+}: ChatMessageProps) {
   switch (message.role) {
     case 'user':
       return <UserMessage message={message} onEdit={onEdit} />
@@ -21,6 +34,8 @@ function ChatMessage({ message, usedTools, onEdit, onRegenerate, isLastAssistant
           usedTools={usedTools}
           onRegenerate={onRegenerate}
           isLastAssistant={isLastAssistant}
+          activeCitationId={activeCitationId}
+          onOpenLibraryCitation={onOpenLibraryCitation}
         />
       )
     default:

--- a/src/components/chat/ChatMessageList.tsx
+++ b/src/components/chat/ChatMessageList.tsx
@@ -3,7 +3,7 @@ import { ChatMessage } from './ChatMessage'
 import { ToolCallIndicator } from './ToolCallIndicator'
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
 import { useAutoScroll } from '@/hooks/useAutoScroll'
-import type { Message } from '@/types/chat'
+import type { LibraryCitation, Message } from '@/types/chat'
 import type { ToolCallState } from '@/hooks/useChat'
 
 interface ChatMessageListProps {
@@ -12,6 +12,11 @@ interface ChatMessageListProps {
   isLoading?: boolean
   onEdit?: (serverId: number, newContent: string) => void
   onRegenerate?: (serverId: number) => void
+  activeCitationId?: string | null
+  onOpenLibraryCitation?: (
+    citation: LibraryCitation,
+    anchorId?: string,
+  ) => void
 }
 
 function isVisibleMessage(msg: Message): boolean {
@@ -59,6 +64,8 @@ function ChatMessageList({
   isLoading = false,
   onEdit,
   onRegenerate,
+  activeCitationId = null,
+  onOpenLibraryCitation,
 }: ChatMessageListProps) {
   const { containerRef, handleScroll } = useAutoScroll([messages, toolCall])
 
@@ -111,6 +118,8 @@ function ChatMessageList({
                 onEdit={onEdit}
                 onRegenerate={onRegenerate}
                 isLastAssistant={message.id === lastAssistantId}
+                activeCitationId={activeCitationId}
+                onOpenLibraryCitation={onOpenLibraryCitation}
               />
             </Fragment>
           )

--- a/src/components/chat/CitationSourcePanel.tsx
+++ b/src/components/chat/CitationSourcePanel.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { Icon } from '@iconify/react'
+import { fetchDocumentDetail } from '@/api/library'
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner'
+import { cn } from '@/lib/utils'
+import type { Anchor, LibraryCitation } from '@/types/chat'
+
+interface CitationSourcePanelProps {
+  isOpen: boolean
+  citation: LibraryCitation | null
+  activeAnchorId: string | null
+  onSelectAnchor: (anchorId: string) => void
+  onClose: () => void
+}
+
+function CitationSourcePanel({
+  isOpen,
+  citation,
+  activeAnchorId,
+  onSelectAnchor,
+  onClose,
+}: CitationSourcePanelProps) {
+  const anchorListRef = useRef<HTMLDivElement>(null)
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['library', 'documents', citation?.file_id, 'detail'],
+    queryFn: () => fetchDocumentDetail(citation!.file_id),
+    enabled: isOpen && !!citation?.file_id,
+    select: (res) => res.data,
+    staleTime: 30 * 1000,
+  })
+
+  const anchors = citation?.anchors ?? []
+  const activeAnchor = useMemo(() => {
+    if (anchors.length === 0) return null
+    return anchors.find((anchor) => anchor.anchor_id === activeAnchorId) ?? anchors[0]
+  }, [activeAnchorId, anchors])
+
+  useEffect(() => {
+    if (!isOpen || !citation) return
+
+    if (activeAnchorId && citation.anchors.some((a) => a.anchor_id === activeAnchorId)) {
+      return
+    }
+
+    const firstAnchor = citation.anchors[0]?.anchor_id
+    if (firstAnchor) onSelectAnchor(firstAnchor)
+  }, [activeAnchorId, citation, isOpen, onSelectAnchor])
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') onClose()
+    }
+
+    document.addEventListener('keydown', handleEscape)
+    return () => document.removeEventListener('keydown', handleEscape)
+  }, [isOpen, onClose])
+
+  useEffect(() => {
+    if (!activeAnchorId || !anchorListRef.current) return
+    const target = anchorListRef.current.querySelector<HTMLElement>(
+      `[data-anchor-id="${activeAnchorId}"]`,
+    )
+    target?.scrollIntoView({ block: 'nearest' })
+  }, [activeAnchorId])
+
+  if (!isOpen || !citation) return null
+
+  const previewUrl = data?.preview_url
+  const fileName = data?.original_filename ?? citation.file_name
+  const contentType = data?.content_type ?? ''
+  const hasPdfPreview = contentType === 'application/pdf'
+  const frameUrl =
+    previewUrl && hasPdfPreview && activeAnchor?.page
+      ? `${previewUrl}#page=${activeAnchor.page}`
+      : previewUrl
+
+  function renderViewer() {
+    if (isLoading) {
+      return (
+        <div className="flex h-full items-center justify-center">
+          <LoadingSpinner size="lg" />
+        </div>
+      )
+    }
+
+    if (isError || !previewUrl) {
+      return (
+        <div className="flex h-full flex-col items-center justify-center gap-2 px-4 text-center text-xs text-zinc-500 dark:text-zinc-400">
+          <p>원본 파일을 불러오지 못했습니다.</p>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="rounded-md border border-zinc-200 px-2 py-1 text-[11px] font-medium text-zinc-600 transition-colors hover:bg-zinc-100 dark:border-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-800"
+          >
+            다시 시도
+          </button>
+        </div>
+      )
+    }
+
+    if (contentType.startsWith('image/')) {
+      return (
+        <div className="flex h-full items-center justify-center bg-zinc-50 p-3 dark:bg-zinc-950">
+          <img
+            src={previewUrl}
+            alt={fileName}
+            className="max-h-full max-w-full rounded object-contain"
+          />
+        </div>
+      )
+    }
+
+    return (
+      <iframe
+        key={frameUrl}
+        src={frameUrl}
+        title={`${fileName} preview`}
+        className="h-full w-full bg-white"
+      />
+    )
+  }
+
+  function renderAnchorMeta(anchor: Anchor): string {
+    const meta: string[] = []
+    if (anchor.page) meta.push(`p.${anchor.page}`)
+    if (anchor.line_start && anchor.line_end) {
+      meta.push(`L${anchor.line_start}-${anchor.line_end}`)
+    } else if (anchor.line_start) {
+      meta.push(`L${anchor.line_start}`)
+    }
+    if (meta.length > 0) return meta.join(' · ')
+    return `char ${anchor.start_char}-${anchor.end_char}`
+  }
+
+  return (
+    <div className="fixed inset-0 z-40 bg-black/40 lg:static lg:z-auto lg:bg-transparent">
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute inset-0 lg:hidden"
+        aria-label="패널 닫기"
+      />
+
+      <aside className="absolute right-0 top-0 z-10 flex h-full w-full max-w-[420px] flex-col border-l border-zinc-200 bg-white dark:border-zinc-700 dark:bg-zinc-900 lg:relative lg:w-[420px]">
+        <header className="flex items-start justify-between gap-2 border-b border-zinc-200 px-3 py-2 dark:border-zinc-700">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-zinc-800 dark:text-zinc-100">
+              {fileName}
+            </p>
+            <p className="mt-0.5 text-[11px] text-zinc-500 dark:text-zinc-400">
+              인용 {anchors.length}개
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-700 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+            aria-label="패널 닫기"
+          >
+            <Icon icon="solar:close-circle-linear" width={18} />
+          </button>
+        </header>
+
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <div className="h-[45%] min-h-[220px] border-b border-zinc-100 dark:border-zinc-800">
+            {renderViewer()}
+          </div>
+
+          <div
+            ref={anchorListRef}
+            className="h-[55%] overflow-y-auto px-3 py-3"
+          >
+            <p className="mb-2 text-xs font-medium text-zinc-600 dark:text-zinc-300">
+              참조된 텍스트
+            </p>
+            {anchors.length === 0 ? (
+              <div className="rounded-lg border border-zinc-200 px-3 py-2 text-xs text-zinc-500 dark:border-zinc-700 dark:text-zinc-400">
+                인용 위치 정보가 없습니다.
+              </div>
+            ) : (
+              <ul className="space-y-2">
+                {anchors.map((anchor) => {
+                  const isActive = anchor.anchor_id === activeAnchor?.anchor_id
+
+                  return (
+                    <li key={anchor.anchor_id}>
+                      <button
+                        type="button"
+                        data-anchor-id={anchor.anchor_id}
+                        onClick={() => onSelectAnchor(anchor.anchor_id)}
+                        className={cn(
+                          'w-full rounded-lg border px-2 py-2 text-left transition-colors',
+                          isActive
+                            ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-700 dark:bg-emerald-950/50'
+                            : 'border-zinc-200 hover:bg-zinc-50 dark:border-zinc-700 dark:hover:bg-zinc-800/60',
+                        )}
+                      >
+                        <p className="text-[11px] font-medium text-zinc-500 dark:text-zinc-400">
+                          {renderAnchorMeta(anchor)}
+                        </p>
+                        <p className="mt-1 line-clamp-4 text-xs text-zinc-700 dark:text-zinc-200">
+                          <mark className="rounded bg-yellow-100 px-0.5 text-inherit dark:bg-yellow-900/60">
+                            {anchor.quote || '참조 텍스트 없음'}
+                          </mark>
+                        </p>
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      </aside>
+    </div>
+  )
+}
+
+export { CitationSourcePanel }

--- a/src/components/chat/MarkdownRenderer.tsx
+++ b/src/components/chat/MarkdownRenderer.tsx
@@ -5,96 +5,183 @@ import type { Components } from 'react-markdown'
 
 interface MarkdownRendererProps {
   content: string
+  onCitationClick?: (citationId: string) => void
 }
 
-const components: Components = {
-  code({ className, children, ...props }) {
-    const match = /language-(\w+)/.exec(className ?? '')
-    const codeString = String(children).replace(/\n$/, '')
+const RAW_CITATION_MARKER_PATTERN =
+  /\\?\[\s*([^[\]:]{1,20})\s*[:：]\s*(\d+)\s*\\?\]/gi
 
-    if (match) {
-      return <CodeBlock language={match[1]}>{codeString}</CodeBlock>
-    }
+function isCitationLabel(label: string): boolean {
+  const normalized = label.trim().toLowerCase().replace(/\s+/g, '')
+  if (!normalized) return false
 
-    return (
-      <code
-        className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200"
-        {...props}
-      >
-        {children}
-      </code>
-    )
-  },
-  p({ children }) {
-    return <p className="mb-3 leading-relaxed last:mb-0">{children}</p>
-  },
-  ul({ children }) {
-    return <ul className="mb-3 list-disc space-y-1 pl-6 last:mb-0">{children}</ul>
-  },
-  ol({ children }) {
-    return <ol className="mb-3 list-decimal space-y-1 pl-6 last:mb-0">{children}</ol>
-  },
-  li({ children }) {
-    return <li className="leading-relaxed">{children}</li>
-  },
-  h1({ children }) {
-    return <h1 className="mb-3 text-xl font-semibold">{children}</h1>
-  },
-  h2({ children }) {
-    return <h2 className="mb-3 text-lg font-semibold">{children}</h2>
-  },
-  h3({ children }) {
-    return <h3 className="mb-2 text-base font-semibold">{children}</h3>
-  },
-  blockquote({ children }) {
-    return (
-      <blockquote className="mb-3 border-l-4 border-zinc-300 pl-4 italic text-zinc-600 dark:border-zinc-600 dark:text-zinc-400">
-        {children}
-      </blockquote>
-    )
-  },
-  a({ href, children }) {
-    return (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-blue-600 underline hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
-      >
-        {children}
-      </a>
-    )
-  },
-  table({ children }) {
-    return (
-      <div className="mb-3 overflow-x-auto">
-        <table className="min-w-full border-collapse border border-zinc-200 text-sm dark:border-zinc-700">
+  const known = new Set([
+    'cite',
+    'citation',
+    'source',
+    'src',
+    '출처',
+    '인용',
+    '시민투입',
+  ])
+  if (known.has(normalized)) return true
+  if (normalized.includes('cite')) return true
+  if (normalized.includes('source')) return true
+  return false
+}
+
+function resolveCitationIdFromHref(href?: string): string | null {
+  if (!href) return null
+
+  const libMatch = href.match(/^#citation-lib-(\d+)$/i)
+  if (libMatch) {
+    return `lib-${libMatch[1]}`
+  }
+
+  const directLibMatch = href.match(/^#citation-(lib-\d+)$/i)
+  if (directLibMatch) {
+    return directLibMatch[1].toLowerCase()
+  }
+
+  const numberOnlyMatch = href.match(/^#citation-(\d+)$/i)
+  if (numberOnlyMatch) {
+    return `lib-${numberOnlyMatch[1]}`
+  }
+
+  return null
+}
+
+function getCitationIndex(citationId: string): string | null {
+  const matched = citationId.match(/(\d+)$/)
+  return matched ? matched[1] : null
+}
+
+function createComponents(
+  onCitationClick?: (citationId: string) => void,
+): Components {
+  return {
+    code({ className, children, ...props }) {
+      const match = /language-(\w+)/.exec(className ?? '')
+      const codeString = String(children).replace(/\n$/, '')
+
+      if (match) {
+        return <CodeBlock language={match[1]}>{codeString}</CodeBlock>
+      }
+
+      return (
+        <code
+          className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm text-zinc-800 dark:bg-zinc-800 dark:text-zinc-200"
+          {...props}
+        >
           {children}
-        </table>
-      </div>
-    )
-  },
-  th({ children }) {
-    return (
-      <th className="border border-zinc-200 bg-zinc-100 px-3 py-2 text-left font-medium dark:border-zinc-700 dark:bg-zinc-800">
-        {children}
-      </th>
-    )
-  },
-  td({ children }) {
-    return (
-      <td className="border border-zinc-200 px-3 py-2 dark:border-zinc-700">
-        {children}
-      </td>
-    )
-  },
+        </code>
+      )
+    },
+    p({ children }) {
+      return <p className="mb-3 leading-relaxed last:mb-0">{children}</p>
+    },
+    ul({ children }) {
+      return (
+        <ul className="mb-3 list-disc space-y-1 pl-6 last:mb-0">{children}</ul>
+      )
+    },
+    ol({ children }) {
+      return (
+        <ol className="mb-3 list-decimal space-y-1 pl-6 last:mb-0">{children}</ol>
+      )
+    },
+    li({ children }) {
+      return <li className="leading-relaxed">{children}</li>
+    },
+    h1({ children }) {
+      return <h1 className="mb-3 text-xl font-semibold">{children}</h1>
+    },
+    h2({ children }) {
+      return <h2 className="mb-3 text-lg font-semibold">{children}</h2>
+    },
+    h3({ children }) {
+      return <h3 className="mb-2 text-base font-semibold">{children}</h3>
+    },
+    blockquote({ children }) {
+      return (
+        <blockquote className="mb-3 border-l-4 border-zinc-300 pl-4 italic text-zinc-600 dark:border-zinc-600 dark:text-zinc-400">
+          {children}
+        </blockquote>
+      )
+    },
+    a({ href, children }) {
+      const citationId = resolveCitationIdFromHref(href)
+      if (citationId) {
+        const citationIndex = getCitationIndex(citationId)
+        const label = citationIndex ? `출처 ${citationIndex}` : '출처'
+
+        return (
+          <button
+            type="button"
+            onClick={() => onCitationClick?.(citationId)}
+            className="mx-0.5 inline-flex items-center gap-1 rounded-full border border-emerald-200 bg-emerald-50 px-2 py-0.5 text-[11px] font-semibold text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-300 dark:hover:bg-emerald-900"
+            aria-label={label}
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500/80" />
+            <span>{label}</span>
+            <span className="sr-only">{children}</span>
+          </button>
+        )
+      }
+
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 underline hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+        >
+          {children}
+        </a>
+      )
+    },
+    table({ children }) {
+      return (
+        <div className="mb-3 overflow-x-auto">
+          <table className="min-w-full border-collapse border border-zinc-200 text-sm dark:border-zinc-700">
+            {children}
+          </table>
+        </div>
+      )
+    },
+    th({ children }) {
+      return (
+        <th className="border border-zinc-200 bg-zinc-100 px-3 py-2 text-left font-medium dark:border-zinc-700 dark:bg-zinc-800">
+          {children}
+        </th>
+      )
+    },
+    td({ children }) {
+      return (
+        <td className="border border-zinc-200 px-3 py-2 dark:border-zinc-700">
+          {children}
+        </td>
+      )
+    },
+  }
 }
 
-function MarkdownRenderer({ content }: MarkdownRendererProps) {
+function MarkdownRenderer({ content, onCitationClick }: MarkdownRendererProps) {
+  const processedContent = content.replace(
+    RAW_CITATION_MARKER_PATTERN,
+    (match, label: string, num: string) => {
+      if (!isCitationLabel(label)) return match
+      return `[cite:${num}](#citation-lib-${num})`
+    },
+  )
+
   return (
     <div className="prose-sm max-w-none text-zinc-950 dark:text-zinc-50">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
-        {content}
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={createComponents(onCitationClick)}
+      >
+        {processedContent}
       </ReactMarkdown>
     </div>
   )

--- a/src/components/chat/SourcesList.test.tsx
+++ b/src/components/chat/SourcesList.test.tsx
@@ -1,6 +1,40 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { SourcesList } from './SourcesList'
+import type { Citation, LibraryCitation } from '@/types/chat'
+
+function createSources(): Citation[] {
+  return [
+    {
+      citation_id: 'web-1',
+      source_type: 'web',
+      title: '검색 결과',
+      snippet: null,
+      url: 'https://example.com',
+    },
+    {
+      citation_id: 'lib-1',
+      source_type: 'library',
+      title: 'report.pdf',
+      snippet: '요약',
+      file_id: 1,
+      file_name: 'report.pdf',
+      anchors: [
+        {
+          anchor_id: 'a-1',
+          page: 1,
+          line_start: null,
+          line_end: null,
+          start_char: 0,
+          end_char: 10,
+          bbox: null,
+          quote: 'quoted text',
+        },
+      ],
+    },
+  ]
+}
 
 describe('SourcesList', () => {
   it('renders nothing when sources is empty', () => {
@@ -9,13 +43,42 @@ describe('SourcesList', () => {
   })
 
   it('renders source count', () => {
-    render(<SourcesList sources={['doc1.pdf', 'doc2.pdf']} />)
+    render(<SourcesList sources={createSources()} />)
     expect(screen.getByText('출처 (2)')).toBeInTheDocument()
   })
 
-  it('renders each source', () => {
-    render(<SourcesList sources={['report.pdf', 'notes.md']} />)
-    expect(screen.getByText('report.pdf')).toBeInTheDocument()
-    expect(screen.getByText('notes.md')).toBeInTheDocument()
+  it('opens web source in new tab', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const user = userEvent.setup()
+
+    render(<SourcesList sources={createSources()} />)
+    await user.click(screen.getByRole('button', { name: /검색 결과/i }))
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://example.com',
+      '_blank',
+      'noopener,noreferrer',
+    )
+  })
+
+  it('calls onOpenLibraryCitation for library source', async () => {
+    const onOpenLibraryCitation = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <SourcesList
+        sources={createSources()}
+        onOpenLibraryCitation={onOpenLibraryCitation}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /report\.pdf/i }))
+
+    expect(onOpenLibraryCitation).toHaveBeenCalledWith(
+      expect.objectContaining<Partial<LibraryCitation>>({
+        citation_id: 'lib-1',
+      }),
+      'a-1',
+    )
   })
 })

--- a/src/components/chat/SourcesList.tsx
+++ b/src/components/chat/SourcesList.tsx
@@ -1,26 +1,104 @@
 import { Icon } from '@iconify/react'
+import { cn } from '@/lib/utils'
+import type { Citation, LibraryCitation } from '@/types/chat'
 
 interface SourcesListProps {
-  sources: string[]
+  sources: Citation[]
+  activeCitationId?: string | null
+  onOpenLibraryCitation?: (
+    citation: LibraryCitation,
+    anchorId?: string,
+  ) => void
 }
 
-function SourcesList({ sources }: SourcesListProps) {
+function isValidUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function SourcesList({
+  sources,
+  activeCitationId = null,
+  onOpenLibraryCitation,
+}: SourcesListProps) {
   if (sources.length === 0) return null
+
+  const webCount = sources.filter((source) => source.source_type === 'web').length
+  const libraryCount = sources.length - webCount
 
   return (
     <div className="mt-3 rounded-lg border border-zinc-200 p-3 dark:border-zinc-700">
       <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-zinc-500 dark:text-zinc-400">
         <Icon icon="solar:library-linear" width={14} />
         <span>출처 ({sources.length})</span>
+        <span className="text-[11px] text-zinc-400 dark:text-zinc-500">
+          웹 {webCount} · 문서 {libraryCount}
+        </span>
       </div>
       <ul className="space-y-1">
         {sources.map((source) => (
-          <li
-            key={source}
-            className="truncate text-xs text-zinc-600 dark:text-zinc-400"
-            title={source}
-          >
-            {source}
+          <li key={source.citation_id}>
+            {source.source_type === 'web' ? (
+              <button
+                type="button"
+                disabled={!isValidUrl(source.url)}
+                onClick={() =>
+                  window.open(source.url, '_blank', 'noopener,noreferrer')
+                }
+                className={cn(
+                  'flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left text-xs transition-colors',
+                  'text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800',
+                  'disabled:cursor-not-allowed disabled:opacity-50',
+                  activeCitationId === source.citation_id &&
+                    'bg-zinc-100 dark:bg-zinc-800',
+                )}
+              >
+                <Icon icon="solar:global-linear" width={14} className="mt-0.5" />
+                <span className="min-w-0 truncate">
+                  {source.title || source.url}
+                </span>
+                <Icon
+                  icon="solar:arrow-right-up-linear"
+                  width={12}
+                  className="ml-auto mt-0.5 shrink-0"
+                />
+              </button>
+            ) : (
+              <button
+                type="button"
+                onClick={() =>
+                  onOpenLibraryCitation?.(
+                    source,
+                    source.anchors[0]?.anchor_id,
+                  )
+                }
+                className={cn(
+                  'flex w-full items-start gap-1.5 rounded-md px-2 py-1 text-left text-xs transition-colors',
+                  'text-zinc-600 hover:bg-zinc-100 dark:text-zinc-400 dark:hover:bg-zinc-800',
+                  activeCitationId === source.citation_id &&
+                    'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-200',
+                )}
+              >
+                <Icon
+                  icon="solar:file-text-linear"
+                  width={14}
+                  className="mt-0.5 shrink-0"
+                />
+                <span className="min-w-0">
+                  <span className="line-clamp-1 font-medium">
+                    {source.file_name || source.title}
+                  </span>
+                  <span className="line-clamp-1 text-[11px] text-zinc-500 dark:text-zinc-400">
+                    참조 {source.anchors.length}개
+                    {source.snippet ? ` · ${source.snippet}` : ''}
+                  </span>
+                </span>
+              </button>
+            )}
           </li>
         ))}
       </ul>

--- a/src/components/library/IndexStatusBadge.tsx
+++ b/src/components/library/IndexStatusBadge.tsx
@@ -1,0 +1,45 @@
+import { Icon } from '@iconify/react'
+import { cn } from '@/lib/utils'
+import {
+  getIndexStatusLabel,
+  isIndexing,
+  normalizeIndexStatus,
+} from '@/lib/libraryIndexStatus'
+import type { LibraryIndexStatus } from '@/types/library'
+
+interface IndexStatusBadgeProps {
+  status: LibraryIndexStatus | null | undefined
+}
+
+function IndexStatusBadge({ status }: IndexStatusBadgeProps) {
+  const normalized = normalizeIndexStatus(status)
+
+  return (
+    <span
+      className={cn(
+        'inline-flex flex-shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium',
+        normalized === 'ready' &&
+          'bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-300',
+        normalized === 'pending' &&
+          'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300',
+        normalized === 'processing' &&
+          'bg-blue-50 text-blue-700 dark:bg-blue-950 dark:text-blue-300',
+        normalized === 'skipped' &&
+          'bg-yellow-50 text-yellow-800 dark:bg-yellow-950 dark:text-yellow-200',
+        normalized === 'failed' &&
+          'bg-red-50 text-red-700 dark:bg-red-950 dark:text-red-300',
+      )}
+    >
+      {isIndexing(normalized) && (
+        <Icon
+          icon="solar:refresh-circle-linear"
+          width={10}
+          className="animate-spin"
+        />
+      )}
+      <span>{getIndexStatusLabel(normalized)}</span>
+    </span>
+  )
+}
+
+export { IndexStatusBadge }

--- a/src/hooks/useChat.test.ts
+++ b/src/hooks/useChat.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useChat } from './useChat'
 import { AllProviders } from '@/test/utils'
+import type { Message } from '@/types/chat'
 
 const mockNavigate = vi.fn()
 vi.mock('react-router', async () => {
@@ -183,6 +184,275 @@ describe('useChat', () => {
       expect.any(Object),
       expect.any(AbortSignal),
     )
+  })
+
+  it('passes selectedDocumentIds option to streamChat', async () => {
+    mockStreamChat.mockImplementation(async (_req, handlers) => {
+      handlers.onDone({ conversation_id: 'c1', sources: [] })
+    })
+
+    const { result } = renderHook(() => useChat(), {
+      wrapper: AllProviders,
+    })
+
+    await act(async () => {
+      await result.current.sendMessage('문서 질문', { selectedDocumentIds: [2, 4] })
+    })
+
+    expect(mockStreamChat).toHaveBeenCalledWith(
+      expect.objectContaining({ selected_document_ids: [2, 4] }),
+      expect.any(Object),
+      expect.any(AbortSignal),
+    )
+  })
+
+  it('preserves streamed sources when history payload has no sources', async () => {
+    const streamedSources = [
+      {
+        citation_id: 'lib-1',
+        source_type: 'library' as const,
+        title: 'doc.pdf',
+        snippet: '인용 스니펫',
+        file_id: 15,
+        file_name: 'doc.pdf',
+        anchors: [
+          {
+            anchor_id: 'a-1',
+            page: 1,
+            line_start: null,
+            line_end: null,
+            start_char: 0,
+            end_char: 32,
+            bbox: null,
+            quote: '인용 텍스트',
+          },
+        ],
+      },
+    ]
+
+    mockStreamChat.mockImplementation(async (_req, handlers) => {
+      handlers.onToken('요약 결과 [cite:1]')
+      handlers.onDone({
+        conversation_id: 'c1',
+        user_message_id: 101,
+        ai_message_id: 102,
+        sources: streamedSources,
+      })
+    })
+
+    const { result, rerender } = renderHook(
+      ({ id, initial, loading }) =>
+        useChat({
+          conversationId: id,
+          initialMessages: initial,
+          isHistoryLoading: loading,
+        }),
+      {
+        wrapper: AllProviders,
+        initialProps: {
+          id: undefined as string | undefined,
+          initial: undefined as Message[] | undefined,
+          loading: false,
+        },
+      },
+    )
+
+    await act(async () => {
+      await result.current.sendMessage('문서 요약해')
+    })
+
+    expect(result.current.messages[1].sources).toEqual(streamedSources)
+
+    rerender({
+      id: 'c1',
+      loading: false,
+      initial: [
+        {
+          id: '101',
+          serverId: 101,
+          role: 'user',
+          content: '문서 요약해',
+          createdAt: '2026-02-18T00:00:00Z',
+        },
+        {
+          id: '102',
+          serverId: 102,
+          role: 'assistant',
+          content: '요약 결과 [cite:1]',
+          createdAt: '2026-02-18T00:00:01Z',
+        },
+      ],
+    })
+
+    expect(result.current.messages[1].sources).toEqual(streamedSources)
+  })
+
+  it('builds fallback sources from document_search tool_result when done sources are empty', async () => {
+    mockStreamChat.mockImplementation(async (_req, handlers) => {
+      handlers.onToolCall?.('document_search: {"query":"문서 요약"}')
+      handlers.onToolResult?.(
+        '[Source 3: document_id=15 (page 2)]\n벡터 임베딩 관련 인용 텍스트',
+      )
+      handlers.onToken('요약 결과입니다. [cite:3]')
+      handlers.onDone({
+        conversation_id: 'c1',
+        user_message_id: 201,
+        ai_message_id: 202,
+        sources: [],
+      })
+    })
+
+    const { result } = renderHook(() => useChat(), {
+      wrapper: AllProviders,
+    })
+
+    await act(async () => {
+      await result.current.sendMessage('문서 요약해')
+    })
+
+    expect(result.current.messages[1].sources?.[0]).toMatchObject({
+      citation_id: 'lib-3',
+      source_type: 'library',
+      file_id: 15,
+    })
+  })
+
+  it('hydrates fallback sources from stored tool messages', () => {
+    const toolContent =
+      '[Source 3: document_id=15 (page 2)]\n벡터 임베딩 관련 인용 텍스트'
+
+    const initialMessages: Message[] = [
+      {
+        id: '301',
+        serverId: 301,
+        role: 'user',
+        content: '문서 요약해',
+        createdAt: '2026-02-18T00:00:00Z',
+      },
+      {
+        id: '302',
+        serverId: 302,
+        role: 'tool',
+        content: toolContent,
+        createdAt: '2026-02-18T00:00:01Z',
+        toolName: 'document_search',
+      },
+      {
+        id: '303',
+        serverId: 303,
+        role: 'assistant',
+        content: '요약 결과입니다. [cite:3]',
+        createdAt: '2026-02-18T00:00:02Z',
+      },
+    ]
+
+    const { result } = renderHook(
+      () =>
+        useChat({
+          conversationId: 'c1',
+          initialMessages,
+          isHistoryLoading: false,
+        }),
+      { wrapper: AllProviders },
+    )
+
+    expect(result.current.messages[2].sources?.[0]).toMatchObject({
+      citation_id: 'lib-3',
+      source_type: 'library',
+      file_id: 15,
+    })
+  })
+
+  it('hydrates fallback sources when localized citation marker is used', () => {
+    const toolContent =
+      '[Source 3: document_id=15 (page 2)]\n벡터 임베딩 관련 인용 텍스트'
+
+    const initialMessages: Message[] = [
+      {
+        id: '401',
+        serverId: 401,
+        role: 'user',
+        content: '문서 요약해',
+        createdAt: '2026-02-18T00:00:00Z',
+      },
+      {
+        id: '402',
+        serverId: 402,
+        role: 'tool',
+        content: toolContent,
+        createdAt: '2026-02-18T00:00:01Z',
+        toolName: 'document_search',
+      },
+      {
+        id: '403',
+        serverId: 403,
+        role: 'assistant',
+        content: '요약 결과입니다. [시민투입:3]',
+        createdAt: '2026-02-18T00:00:02Z',
+      },
+    ]
+
+    const { result } = renderHook(
+      () =>
+        useChat({
+          conversationId: 'c1',
+          initialMessages,
+          isHistoryLoading: false,
+        }),
+      { wrapper: AllProviders },
+    )
+
+    expect(result.current.messages[2].sources?.[0]).toMatchObject({
+      citation_id: 'lib-3',
+      source_type: 'library',
+      file_id: 15,
+    })
+  })
+
+  it('hydrates fallback sources when localized marker uses full-width colon', () => {
+    const toolContent =
+      '[Source 4: document_id=19 (page 5)]\n풀와이드 콜론 인용 텍스트'
+
+    const initialMessages: Message[] = [
+      {
+        id: '501',
+        serverId: 501,
+        role: 'user',
+        content: '문서 요약해',
+        createdAt: '2026-02-18T00:00:00Z',
+      },
+      {
+        id: '502',
+        serverId: 502,
+        role: 'tool',
+        content: toolContent,
+        createdAt: '2026-02-18T00:00:01Z',
+        toolName: 'document_search',
+      },
+      {
+        id: '503',
+        serverId: 503,
+        role: 'assistant',
+        content: '요약 결과입니다. [시민투입：4]',
+        createdAt: '2026-02-18T00:00:02Z',
+      },
+    ]
+
+    const { result } = renderHook(
+      () =>
+        useChat({
+          conversationId: 'c1',
+          initialMessages,
+          isHistoryLoading: false,
+        }),
+      { wrapper: AllProviders },
+    )
+
+    expect(result.current.messages[2].sources?.[0]).toMatchObject({
+      citation_id: 'lib-4',
+      source_type: 'library',
+      file_id: 19,
+    })
   })
 
   it('uses initialMessages when provided', () => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -2,7 +2,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { streamChat, streamEditMessage, streamRegenerate } from '@/api/chat'
-import type { ImageSummary, Message } from '@/types/chat'
+import type {
+  ImageSummary,
+  LibraryCitation,
+  Message,
+  SendMessageOptions,
+  StreamDonePayload,
+} from '@/types/chat'
 
 interface ToolCallState {
   name: string
@@ -21,13 +27,204 @@ interface UseChatReturn {
   isLoading: boolean
   error: Error | null
   toolCall: ToolCallState | null
-  sendMessage: (
-    content: string,
-    options?: { useWebSearch?: boolean; images?: File[] },
-  ) => Promise<void>
+  sendMessage: (content: string, options?: SendMessageOptions) => Promise<void>
   editMessage: (messageServerId: number, newContent: string) => Promise<void>
   regenerateMessage: (messageServerId: number) => Promise<void>
   stopStreaming: () => void
+}
+
+interface ParsedDocumentToolSource {
+  sourceIndex: number
+  documentId: number
+  page: number | null
+  quote: string
+}
+
+const TOOL_SOURCE_PATTERN =
+  /\[Source\s+(\d+):\s*document_id=(\d+)(?:\s*\(page\s*(\d+)\))?\]\s*\n([\s\S]*?)(?=\n\s*\[Source\s+\d+:|\s*$)/gi
+
+function isCitationLabel(label: string): boolean {
+  const normalized = label.trim().toLowerCase().replace(/\s+/g, '')
+  if (!normalized) return false
+
+  const known = new Set([
+    'cite',
+    'citation',
+    'source',
+    'src',
+    '출처',
+    '인용',
+    '시민투입',
+  ])
+  if (known.has(normalized)) return true
+  if (normalized.includes('cite')) return true
+  if (normalized.includes('source')) return true
+  return false
+}
+
+function extractCitedIndices(content: string): Set<number> {
+  const result = new Set<number>()
+  const markerPattern = /\[\s*([^[\]:]{1,20})\s*[:：]\s*(\d+)\s*\]/gi
+  for (const match of content.matchAll(markerPattern)) {
+    const label = match[1] ?? ''
+    if (!isCitationLabel(label)) continue
+
+    const index = Number(match[2])
+    if (!Number.isNaN(index) && index > 0) {
+      result.add(index)
+    }
+  }
+  return result
+}
+
+function parseDocumentSearchToolOutput(
+  output: string,
+): ParsedDocumentToolSource[] {
+  const parsed: ParsedDocumentToolSource[] = []
+  for (const match of output.matchAll(new RegExp(TOOL_SOURCE_PATTERN.source, 'gi'))) {
+    const sourceIndex = Number(match[1])
+    const documentId = Number(match[2])
+    const page = match[3] ? Number(match[3]) : null
+    const quote = match[4]?.trim() ?? ''
+
+    if (
+      Number.isNaN(sourceIndex) ||
+      sourceIndex <= 0 ||
+      Number.isNaN(documentId) ||
+      documentId <= 0 ||
+      !quote
+    ) {
+      continue
+    }
+
+    parsed.push({
+      sourceIndex,
+      documentId,
+      page: Number.isNaN(page ?? Number.NaN) ? null : page,
+      quote,
+    })
+  }
+
+  const byIndex = new Map<number, ParsedDocumentToolSource>()
+  for (const source of parsed) {
+    if (!byIndex.has(source.sourceIndex)) {
+      byIndex.set(source.sourceIndex, source)
+    }
+  }
+  return Array.from(byIndex.values())
+}
+
+function buildLibrarySourcesFromToolOutput(
+  aiContent: string,
+  toolOutput: string,
+): LibraryCitation[] {
+  if (!toolOutput.trim()) return []
+
+  const allSources = parseDocumentSearchToolOutput(toolOutput)
+  if (allSources.length === 0) return []
+
+  const citedIndices = extractCitedIndices(aiContent)
+  const selectedSources =
+    citedIndices.size > 0
+      ? allSources.filter((source) => citedIndices.has(source.sourceIndex))
+      : allSources
+
+  const targetSources = selectedSources.length > 0 ? selectedSources : allSources
+
+  return targetSources.map((source) => {
+    const quote = source.quote.slice(0, 240)
+    return {
+      citation_id: `lib-${source.sourceIndex}`,
+      source_type: 'library',
+      title: `Document ${source.documentId}`,
+      snippet: quote.slice(0, 120),
+      file_id: source.documentId,
+      file_name: `document_${source.documentId}`,
+      anchors: [
+        {
+          anchor_id: `a-fallback-${source.sourceIndex}`,
+          page: source.page,
+          line_start: null,
+          line_end: null,
+          start_char: 0,
+          end_char: quote.length,
+          bbox: null,
+          quote,
+        },
+      ],
+    }
+  })
+}
+
+function hydrateSourcesFromToolMessages(incoming: Message[]): Message[] {
+  if (incoming.length === 0) return incoming
+
+  const hydrated = [...incoming]
+
+  for (let i = 0; i < hydrated.length; i++) {
+    const current = hydrated[i]
+    if (current.role !== 'assistant') continue
+    if (current.sources && current.sources.length > 0) continue
+    if (extractCitedIndices(current.content).size === 0) continue
+
+    let documentToolOutput = ''
+    for (let j = i - 1; j >= 0; j--) {
+      const prev = hydrated[j]
+      if (prev.role === 'user') break
+      if (
+        prev.role === 'tool' &&
+        prev.toolName === 'document_search' &&
+        prev.content
+      ) {
+        documentToolOutput = `${prev.content}\n\n${documentToolOutput}`
+      }
+    }
+
+    const fallbackSources = buildLibrarySourcesFromToolOutput(
+      current.content,
+      documentToolOutput,
+    )
+    if (fallbackSources.length === 0) continue
+
+    hydrated[i] = {
+      ...current,
+      sources: fallbackSources,
+    }
+  }
+
+  return hydrated
+}
+
+function mergeMessagesWithLocalState(
+  current: Message[],
+  incoming: Message[],
+): Message[] {
+  if (current.length === 0) return incoming
+
+  const localByServerId = new Map<number, Message>()
+  for (const msg of current) {
+    if (msg.serverId !== null) {
+      localByServerId.set(msg.serverId, msg)
+    }
+  }
+
+  return incoming.map((msg) => {
+    if (msg.serverId === null) return msg
+
+    const local = localByServerId.get(msg.serverId)
+    if (!local) return msg
+
+    return {
+      ...msg,
+      sources:
+        msg.sources && msg.sources.length > 0 ? msg.sources : local.sources,
+      toolCalls:
+        msg.toolCalls && msg.toolCalls.length > 0
+          ? msg.toolCalls
+          : local.toolCalls,
+      images: msg.images && msg.images.length > 0 ? msg.images : local.images,
+    }
+  })
 }
 
 function useChat(options: UseChatOptions = {}): UseChatReturn {
@@ -40,6 +237,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
   const [toolCall, setToolCall] = useState<ToolCallState | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
   const conversationIdRef = useRef(conversationId)
+  const latestDocumentToolOutputRef = useRef('')
 
   useEffect(() => {
     conversationIdRef.current = conversationId
@@ -47,7 +245,8 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
 
   useEffect(() => {
     if (initialMessages && initialMessages.length > 0) {
-      setMessages(initialMessages)
+      const hydrated = hydrateSourcesFromToolMessages(initialMessages)
+      setMessages((prev) => mergeMessagesWithLocalState(prev, hydrated))
     } else if (!isHistoryLoading) {
       setMessages([])
     }
@@ -58,6 +257,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
   const stopStreaming = useCallback(() => {
     abortControllerRef.current?.abort()
     abortControllerRef.current = null
+    latestDocumentToolOutputRef.current = ''
     setIsStreaming(false)
   }, [])
 
@@ -70,6 +270,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
         return updated
       })
       setIsStreaming(false)
+      latestDocumentToolOutputRef.current = ''
       return
     }
 
@@ -86,6 +287,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
     })
     setIsStreaming(false)
     setToolCall(null)
+    latestDocumentToolOutputRef.current = ''
   }, [])
 
   const createStreamHandlers = useCallback(
@@ -103,25 +305,80 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
         })
       },
       onToolCall: (data: unknown) => {
+        if (typeof data === 'string') {
+          const parsedName = data.split(':', 1)[0]?.trim()
+          setToolCall({ name: parsedName || 'tool', status: 'calling' })
+          return
+        }
+
         const parsed = data as { name?: string }
         setToolCall({ name: parsed.name ?? 'tool', status: 'calling' })
       },
-      onToolResult: () => {
+      onToolResult: (data: unknown) => {
+        if (
+          typeof data === 'string' &&
+          data.includes('[Source') &&
+          data.includes('document_id=')
+        ) {
+          latestDocumentToolOutputRef.current = `${latestDocumentToolOutputRef.current}\n\n${data}`.trim()
+        }
         setToolCall((prev) => (prev ? { ...prev, status: 'done' } : null))
       },
-      onDone: (data: { conversation_id: string; sources: string[] }) => {
+      onDone: (data: StreamDonePayload) => {
+        const fallbackToolOutput = latestDocumentToolOutputRef.current
+
         setMessages((prev) => {
+          if (prev.length === 0) return prev
+
           const updated = [...prev]
-          const last = updated[updated.length - 1]
-          updated[updated.length - 1] = {
-            ...last,
-            isStreaming: false,
-            sources: data.sources,
+
+          let assistantIndex = -1
+          for (let i = updated.length - 1; i >= 0; i--) {
+            if (updated[i].role === 'assistant') {
+              assistantIndex = i
+              break
+            }
           }
+
+          if (assistantIndex !== -1) {
+            const assistantMessage = updated[assistantIndex]
+            const fallbackSources =
+              (!data.sources || data.sources.length === 0) && fallbackToolOutput
+                ? buildLibrarySourcesFromToolOutput(
+                    assistantMessage.content,
+                    fallbackToolOutput,
+                  )
+                : []
+
+            updated[assistantIndex] = {
+              ...assistantMessage,
+              isStreaming: false,
+              serverId: data.ai_message_id ?? assistantMessage.serverId,
+              sources:
+                data.sources && data.sources.length > 0
+                  ? data.sources
+                  : fallbackSources,
+            }
+          }
+
+          if (data.user_message_id !== undefined && data.user_message_id !== null) {
+            for (let i = assistantIndex - 1; i >= 0; i--) {
+              if (updated[i].role === 'user') {
+                const userMessage = updated[i]
+                updated[i] = {
+                  ...userMessage,
+                  serverId: userMessage.serverId ?? data.user_message_id,
+                }
+                break
+              }
+            }
+          }
+
           return updated
         })
         setIsStreaming(false)
         setToolCall(null)
+        latestDocumentToolOutputRef.current = ''
 
         if (!conversationIdRef.current && data.conversation_id) {
           conversationIdRef.current = data.conversation_id
@@ -149,15 +406,17 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
         })
         setIsStreaming(false)
         setToolCall(null)
+        latestDocumentToolOutputRef.current = ''
       },
     }),
     [navigate, queryClient],
   )
 
   const sendMessage = useCallback(
-    async (content: string, options?: { useWebSearch?: boolean; images?: File[] }) => {
+    async (content: string, options?: SendMessageOptions) => {
       setError(null)
       setToolCall(null)
+      latestDocumentToolOutputRef.current = ''
 
       const localImages: ImageSummary[] | undefined =
         options?.images && options.images.length > 0
@@ -206,6 +465,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
             message: content,
             conversation_id: conversationIdRef.current,
             use_web_search: options?.useWebSearch,
+            selected_document_ids: options?.selectedDocumentIds,
             images: options?.images,
           },
           createStreamHandlers(),
@@ -226,6 +486,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
 
       setError(null)
       setToolCall(null)
+      latestDocumentToolOutputRef.current = ''
 
       setMessages((prev) => {
         const targetIndex = prev.findIndex(
@@ -278,6 +539,7 @@ function useChat(options: UseChatOptions = {}): UseChatReturn {
 
       setError(null)
       setToolCall(null)
+      latestDocumentToolOutputRef.current = ''
 
       setMessages((prev) => {
         const targetIndex = prev.findIndex(

--- a/src/hooks/useChatDocuments.ts
+++ b/src/hooks/useChatDocuments.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchDocuments } from '@/api/library'
+import { isIndexing } from '@/lib/libraryIndexStatus'
+
+const CHAT_DOCUMENTS_PAGE_SIZE = 100
+const CHAT_DOCUMENTS_POLL_INTERVAL = 5000
+
+function useChatDocuments() {
+  return useQuery({
+    queryKey: ['chat', 'documents'],
+    queryFn: () =>
+      fetchDocuments({
+        page: 1,
+        size: CHAT_DOCUMENTS_PAGE_SIZE,
+        include_archived: false,
+      }),
+    refetchInterval: (query) => {
+      const documents = query.state.data?.data?.documents
+      if (!documents) return false
+      return documents.some((doc) => isIndexing(doc.index_status))
+        ? CHAT_DOCUMENTS_POLL_INTERVAL
+        : false
+    },
+    select: (res) => res.data?.documents ?? [],
+  })
+}
+
+export { useChatDocuments }

--- a/src/hooks/useLibraryDocuments.ts
+++ b/src/hooks/useLibraryDocuments.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { fetchDocuments, fetchStorageUsage } from '@/api/library'
 import { useLibraryStore } from '@/stores/libraryStore'
 import { LIBRARY_PAGE_SIZE } from '@/lib/constants'
+import { isIndexing } from '@/lib/libraryIndexStatus'
 
 const SUMMARY_POLL_INTERVAL = 5000
 
@@ -30,7 +31,10 @@ function useLibraryDocuments(page: number = 1) {
       const docs = query.state.data?.data?.documents
       if (!docs) return false
       const hasPending = docs.some(
-        (d) => d.summary_status === 'pending' || d.summary_status === 'processing',
+        (d) =>
+          d.summary_status === 'pending' ||
+          d.summary_status === 'processing' ||
+          isIndexing(d.index_status),
       )
       return hasPending ? SUMMARY_POLL_INTERVAL : false
     },

--- a/src/hooks/useLibraryMutations.test.ts
+++ b/src/hooks/useLibraryMutations.test.ts
@@ -1,13 +1,19 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
-import { useUpdateDocumentStatus, useDeleteDocument } from './useLibraryMutations'
+import {
+  useUpdateDocumentStatus,
+  useDeleteDocument,
+  useReindexDocument,
+} from './useLibraryMutations'
 import { AllProviders } from '@/test/utils'
 
 const mockUpdateDocumentStatus = vi.fn()
 const mockDeleteDocument = vi.fn()
+const mockReindexDocument = vi.fn()
 
 vi.mock('@/api/library', () => ({
   updateDocumentStatus: (...args: unknown[]) => mockUpdateDocumentStatus(...args),
   deleteDocument: (...args: unknown[]) => mockDeleteDocument(...args),
+  reindexDocument: (...args: unknown[]) => mockReindexDocument(...args),
 }))
 
 describe('useUpdateDocumentStatus', () => {
@@ -59,5 +65,29 @@ describe('useDeleteDocument', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
 
     expect(mockDeleteDocument).toHaveBeenCalledWith(1)
+  })
+})
+
+describe('useReindexDocument', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('문서 재인덱싱을 요청한다', async () => {
+    mockReindexDocument.mockResolvedValue({
+      status: 200,
+      data: { id: 1, index_status: 'pending' },
+    })
+
+    const { result } = renderHook(() => useReindexDocument(), {
+      wrapper: AllProviders,
+    })
+
+    await act(async () => {
+      result.current.mutate(1)
+    })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockReindexDocument).toHaveBeenCalledWith(1)
   })
 })

--- a/src/hooks/useLibraryMutations.ts
+++ b/src/hooks/useLibraryMutations.ts
@@ -1,5 +1,9 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { updateDocumentStatus, deleteDocument } from '@/api/library'
+import {
+  updateDocumentStatus,
+  deleteDocument,
+  reindexDocument,
+} from '@/api/library'
 import type { UpdateStatusRequest } from '@/types/library'
 
 function useUpdateDocumentStatus() {
@@ -26,4 +30,15 @@ function useDeleteDocument() {
   })
 }
 
-export { useUpdateDocumentStatus, useDeleteDocument }
+function useReindexDocument() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (id: number) => reindexDocument(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['library', 'documents'] })
+    },
+  })
+}
+
+export { useUpdateDocumentStatus, useDeleteDocument, useReindexDocument }

--- a/src/lib/libraryIndexStatus.ts
+++ b/src/lib/libraryIndexStatus.ts
@@ -1,0 +1,45 @@
+import type { LibraryIndexStatus } from '@/types/library'
+
+type NormalizedIndexStatus = Exclude<LibraryIndexStatus, null>
+
+function normalizeIndexStatus(
+  status: LibraryIndexStatus | null | undefined,
+): NormalizedIndexStatus {
+  return status ?? 'pending'
+}
+
+function isIndexing(status: LibraryIndexStatus | null | undefined): boolean {
+  const normalized = normalizeIndexStatus(status)
+  return normalized === 'pending' || normalized === 'processing'
+}
+
+function isReadyForSelection(
+  status: LibraryIndexStatus | null | undefined,
+): boolean {
+  return normalizeIndexStatus(status) === 'ready'
+}
+
+function getIndexStatusLabel(
+  status: LibraryIndexStatus | null | undefined,
+): string {
+  switch (normalizeIndexStatus(status)) {
+    case 'pending':
+      return '대기 중'
+    case 'processing':
+      return '인덱싱 중'
+    case 'ready':
+      return '검색 가능'
+    case 'skipped':
+      return '텍스트 없음'
+    case 'failed':
+      return '인덱싱 실패'
+  }
+}
+
+export {
+  normalizeIndexStatus,
+  isIndexing,
+  isReadyForSelection,
+  getIndexStatusLabel,
+}
+export type { NormalizedIndexStatus }

--- a/src/pages/Chat.test.tsx
+++ b/src/pages/Chat.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { screen } from '@testing-library/react'
 import { renderWithProviders } from '@/test/utils'
 import { Chat } from './Chat'
+import { useLibraryStore } from '@/stores/libraryStore'
 
 vi.mock('react-router', async () => {
   const actual = await vi.importActual('react-router')
@@ -19,9 +20,41 @@ vi.mock('@/api/chat', () => ({
   fetchConversationMessages: vi.fn(),
 }))
 
+vi.mock('@/api/library', () => ({
+  fetchDocuments: vi.fn().mockResolvedValue({
+    status: 200,
+    message: 'ok',
+    data: {
+      documents: [
+        {
+          id: 1,
+          original_filename: 'doc.pdf',
+          content_type: 'application/pdf',
+          file_size: 1024,
+          status: 'active',
+          summary: null,
+          summary_status: 'completed',
+          index_status: 'ready',
+          created_at: '2026-02-18T00:00:00Z',
+          updated_at: '2026-02-18T00:00:00Z',
+        },
+      ],
+      total: 1,
+      page: 1,
+      size: 100,
+    },
+  }),
+  reindexDocument: vi.fn().mockResolvedValue({
+    status: 200,
+    message: 'ok',
+    data: null,
+  }),
+}))
+
 describe('Chat', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    useLibraryStore.setState({ selectedIds: new Set<number>() })
   })
 
   it('renders welcome screen when no messages', () => {
@@ -48,5 +81,12 @@ describe('Chat', () => {
     expect(
       screen.getByRole('button', { name: '웹 검색 꺼짐' }),
     ).toBeInTheDocument()
+  })
+
+  it('hydrates selected documents from library selection', () => {
+    useLibraryStore.setState({ selectedIds: new Set<number>([1]) })
+    renderWithProviders(<Chat />)
+
+    expect(screen.getByText('문서 (1)')).toBeInTheDocument()
   })
 })

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,14 +1,34 @@
+import { useEffect, useRef, useState } from 'react'
 import { useParams } from 'react-router'
 import { ChatWelcome } from '@/components/chat/ChatWelcome'
 import { ChatMessageList } from '@/components/chat/ChatMessageList'
 import { ChatInput } from '@/components/chat/ChatInput'
+import { CitationSourcePanel } from '@/components/chat/CitationSourcePanel'
 import { useChat } from '@/hooks/useChat'
+import { useChatDocuments } from '@/hooks/useChatDocuments'
 import { useConversationMessages } from '@/hooks/useConversationMessages'
+import { useReindexDocument } from '@/hooks/useLibraryMutations'
+import { useLibraryStore } from '@/stores/libraryStore'
+import type { LibraryCitation } from '@/types/chat'
 
 function Chat() {
   const { conversationId } = useParams<{ conversationId: string }>()
+  const librarySelectedIds = useLibraryStore((s) => s.selectedIds)
+  const clearLibrarySelection = useLibraryStore((s) => s.clearSelection)
+  const hydratedLibrarySelectionRef = useRef(false)
+  const prevConversationIdRef = useRef<string | undefined>(conversationId)
+  const [selectedDocumentIds, setSelectedDocumentIds] = useState<number[]>(
+    () => Array.from(librarySelectedIds),
+  )
+  const [activeCitation, setActiveCitation] = useState<LibraryCitation | null>(null)
+  const [activeCitationId, setActiveCitationId] = useState<string | null>(null)
+  const [activeAnchorId, setActiveAnchorId] = useState<string | null>(null)
+  const [isSourcePanelOpen, setIsSourcePanelOpen] = useState(false)
+
   const { data: historyMessages, isLoading: isHistoryLoading } =
     useConversationMessages(conversationId)
+  const { data: documents = [], isLoading: isDocumentsLoading } = useChatDocuments()
+  const reindexDocument = useReindexDocument()
 
   const {
     messages,
@@ -25,25 +45,75 @@ function Chat() {
     isHistoryLoading,
   })
 
+  useEffect(() => {
+    if (hydratedLibrarySelectionRef.current) return
+    if (librarySelectedIds.size === 0) return
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- hydrate library selection once on mount
+    setSelectedDocumentIds((prev) => {
+      if (prev.length > 0) return prev
+      return Array.from(librarySelectedIds)
+    })
+    clearLibrarySelection()
+    hydratedLibrarySelectionRef.current = true
+  }, [clearLibrarySelection, librarySelectedIds])
+
+  useEffect(() => {
+    const prevConversationId = prevConversationIdRef.current
+    if (prevConversationId !== undefined && prevConversationId !== conversationId) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- reset state on conversation change
+      setSelectedDocumentIds([])
+      setActiveCitation(null)
+      setActiveCitationId(null)
+      setActiveAnchorId(null)
+      setIsSourcePanelOpen(false)
+    }
+    prevConversationIdRef.current = conversationId
+  }, [conversationId])
+
+  function handleOpenLibraryCitation(citation: LibraryCitation, anchorId?: string) {
+    setActiveCitation(citation)
+    setActiveCitationId(citation.citation_id)
+    setActiveAnchorId(anchorId ?? citation.anchors[0]?.anchor_id ?? null)
+    setIsSourcePanelOpen(true)
+  }
+
   const isEmpty = messages.length === 0 && !isLoading
 
   return (
-    <div className="flex flex-1 flex-col overflow-hidden">
-      {isEmpty ? (
-        <ChatWelcome />
-      ) : (
-        <ChatMessageList
-          messages={messages}
-          toolCall={toolCall}
-          isLoading={isLoading}
-          onEdit={editMessage}
-          onRegenerate={regenerateMessage}
+    <div className="flex flex-1 overflow-hidden">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        {isEmpty ? (
+          <ChatWelcome />
+        ) : (
+          <ChatMessageList
+            messages={messages}
+            toolCall={toolCall}
+            isLoading={isLoading}
+            onEdit={editMessage}
+            onRegenerate={regenerateMessage}
+            activeCitationId={activeCitationId}
+            onOpenLibraryCitation={handleOpenLibraryCitation}
+          />
+        )}
+        <ChatInput
+          onSend={sendMessage}
+          isStreaming={isStreaming}
+          onStop={stopStreaming}
+          documents={documents}
+          isDocumentsLoading={isDocumentsLoading}
+          selectedDocumentIds={selectedDocumentIds}
+          onSelectedDocumentIdsChange={setSelectedDocumentIds}
+          onReindexDocument={(documentId) => reindexDocument.mutate(documentId)}
         />
-      )}
-      <ChatInput
-        onSend={sendMessage}
-        isStreaming={isStreaming}
-        onStop={stopStreaming}
+      </div>
+
+      <CitationSourcePanel
+        isOpen={isSourcePanelOpen}
+        citation={activeCitation}
+        activeAnchorId={activeAnchorId}
+        onSelectAnchor={setActiveAnchorId}
+        onClose={() => setIsSourcePanelOpen(false)}
       />
     </div>
   )

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,14 +1,47 @@
+export interface Anchor {
+  anchor_id: string
+  page: number | null
+  line_start: number | null
+  line_end: number | null
+  start_char: number
+  end_char: number
+  bbox: number[] | null
+  quote: string
+}
+
+export interface WebCitation {
+  citation_id: string
+  source_type: 'web'
+  title: string | null
+  snippet: string | null
+  url: string
+}
+
+export interface LibraryCitation {
+  citation_id: string
+  source_type: 'library'
+  title: string
+  snippet: string | null
+  file_id: number
+  file_name: string
+  anchors: Anchor[]
+}
+
+export type Citation = WebCitation | LibraryCitation
+
 export interface ChatRequest {
   message: string
   conversation_id?: string
   use_web_search?: boolean
+  selected_document_ids?: number[]
+  images?: File[]
 }
 
 export interface ChatResponse {
   message: string
   conversation_id: string
   session_id: number
-  sources: string[]
+  sources: Citation[]
   created_at: string
 }
 
@@ -22,6 +55,16 @@ export type StreamEventType =
 export interface StreamEvent {
   event: StreamEventType
   data: string
+}
+
+export interface StreamDonePayload {
+  conversation_id: string
+  session_id?: number
+  is_new_session?: boolean
+  user_message_id?: number | null
+  ai_message_id?: number | null
+  image_ids?: number[]
+  sources: Citation[]
 }
 
 export interface ImageSummary {
@@ -58,13 +101,19 @@ export interface Message {
   serverId: number | null
   role: 'user' | 'assistant' | 'tool'
   content: string
-  sources?: string[]
+  sources?: Citation[]
   isStreaming?: boolean
   createdAt: string
   toolCalls?: ToolCallInfo[]
   toolCallId?: string
   toolName?: string
   images?: ImageSummary[]
+}
+
+export interface SendMessageOptions {
+  useWebSearch?: boolean
+  images?: File[]
+  selectedDocumentIds?: number[]
 }
 
 export interface EditMessageRequest {

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -1,3 +1,10 @@
+export type LibraryIndexStatus =
+  | 'pending'
+  | 'processing'
+  | 'ready'
+  | 'skipped'
+  | 'failed'
+
 export interface LibraryDocument {
   id: number
   original_filename: string
@@ -6,6 +13,7 @@ export interface LibraryDocument {
   status: 'active' | 'archived'
   summary: string | null
   summary_status: 'pending' | 'processing' | 'completed' | 'failed'
+  index_status: LibraryIndexStatus | null
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
## Summary
- 문서 라이브러리 RAG citation 프론트엔드 구현
- Citation 클릭 시 원본 문서 패널 표시 기능 추가
- 백엔드 `langchain-chat#28` 변경과 연동

## Changes
### New Files
| File | Description |
|------|-------------|
| `src/components/chat/CitationSourcePanel.tsx` | 우측 citation 소스 패널 (문서 미리보기 + anchor 하이라이트) |
| `src/components/library/IndexStatusBadge.tsx` | 문서 인덱싱 상태 뱃지 (pending/processing/ready/failed) |
| `src/hooks/useChatDocuments.ts` | 채팅 문서 선택 상태 관리 훅 |
| `src/lib/libraryIndexStatus.ts` | 인덱싱 상태 유틸리티 |

### Modified Files
| File | Changes |
|------|---------|
| `src/types/chat.ts` | `Anchor`, `WebCitation`, `LibraryCitation`, `StreamDonePayload`, `SendMessageOptions` 타입 추가 |
| `src/types/library.ts` | `LibraryIndexStatus` 타입 추가, `index_status` 필드 추가 |
| `src/api/chat.ts` | `selected_document_ids` FormData 전송 지원 |
| `src/api/sse.ts` | SSE done 이벤트에서 sources 파싱 |
| `src/components/chat/MarkdownRenderer.tsx` | `[cite:N]` 마커를 클릭 가능한 인라인 뱃지로 변환 |
| `src/components/chat/AssistantMessage.tsx` | Citation 소스 목록 렌더링 |
| `src/components/chat/SourcesList.tsx` | WebCitation/LibraryCitation 분리 렌더링 |
| `src/components/chat/ChatInput.tsx` | 문서 선택 UI 추가 |
| `src/hooks/useChat.ts` | `selected_document_ids` 전송, sources 바인딩, citation 인덱스 추출 |
| `src/pages/Chat.tsx` | CitationSourcePanel 통합, 문서 선택 상태 관리 |

## Test Plan
- [x] citation 관련 155개 테스트 통과
- [x] 린트 에러 0개

Closes heemanglee/langchain-chat#28

🤖 Generated with [Claude Code](https://claude.ai/code)